### PR TITLE
Various guest user registration stuff and related logging

### DIFF
--- a/conduit-example.toml
+++ b/conduit-example.toml
@@ -81,3 +81,6 @@ allow_device_name_federation = false
 # Most users should not need to enable this.
 # See https://breachattack.com/ and https://wikipedia.org/wiki/BREACH before deciding to enable this.
 zstd_compression = false
+
+# Set to true to allow user type "guest" registrations
+allow_guest_registration = false

--- a/src/api/client_server/account.rs
+++ b/src/api/client_server/account.rs
@@ -89,9 +89,10 @@ pub async fn register_route(body: Ruma<register::v3::Request>) -> Result<registe
 
     if is_guest
         && (!services().globals.allow_guest_registration()
-            || !services().globals.allow_registration())
+            || (!services().globals.allow_registration()
+                && services().globals.config.registration_token.is_some()))
     {
-        info!("Guest registration disabled / registration fully disabled, rejecting guest registration, initial device name: {:?}", body.initial_device_display_name);
+        info!("Guest registration disabled / registration disabled with token configured, rejecting guest registration, initial device name: {:?}", body.initial_device_display_name);
         return Err(Error::BadRequest(
             ErrorKind::GuestAccessForbidden,
             "Guest registration is disabled.",

--- a/src/api/client_server/account.rs
+++ b/src/api/client_server/account.rs
@@ -13,7 +13,7 @@ use ruma::{
     events::{room::message::RoomMessageEventContent, GlobalAccountDataEventType},
     push, UserId,
 };
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use register::RegistrationKind;
 
@@ -270,6 +270,9 @@ pub async fn register_route(body: Ruma<register::v3::Request>) -> Result<registe
             .await?;
 
         warn!("Granting {} admin privileges as the first user", user_id);
+    } else {
+        error!("First registered user \"{user_id}\" is a guest account, not granting admin privileges.\n
+        Recommend disabling public and guest registrations, and using emergency password to get access back, or reset your database with disabled registration.");
     }
 
     Ok(register::v3::Response {

--- a/src/api/client_server/account.rs
+++ b/src/api/client_server/account.rs
@@ -86,6 +86,17 @@ pub async fn register_route(body: Ruma<register::v3::Request>) -> Result<registe
 
     let is_guest = body.kind == RegistrationKind::Guest;
 
+    if is_guest
+        && (!services().globals.allow_guest_registration()
+            || !services().globals.allow_registration())
+    {
+        info!("Guest registration disabled / registration fully disabled, rejecting guest registration, initial device name: {:?}", body.initial_device_display_name);
+        return Err(Error::BadRequest(
+            ErrorKind::GuestAccessForbidden,
+            "Guest registration is disabled.",
+        ));
+    }
+
     let user_id = match (&body.username, is_guest) {
         (Some(username), false) => {
             let proposed_user_id = UserId::parse_with_server_name(

--- a/src/api/client_server/account.rs
+++ b/src/api/client_server/account.rs
@@ -13,7 +13,7 @@ use ruma::{
     events::{room::message::RoomMessageEventContent, GlobalAccountDataEventType},
     push, UserId,
 };
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use register::RegistrationKind;
 
@@ -280,9 +280,6 @@ pub async fn register_route(body: Ruma<register::v3::Request>) -> Result<registe
             .await?;
 
         warn!("Granting {} admin privileges as the first user", user_id);
-    } else {
-        error!("First registered user \"{user_id}\" is a guest account, not granting admin privileges.\n
-        Recommend disabling public and guest registrations, and using emergency password to get access back, or reset your database with disabled registration.");
     }
 
     Ok(register::v3::Response {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -119,6 +119,9 @@ pub struct Config {
     #[serde(default = "false_fn")]
     pub zstd_compression: bool,
 
+    #[serde(default = "false_fn")]
+    pub allow_guest_registration: bool,
+
     #[serde(flatten)]
     pub catchall: BTreeMap<String, IgnoredAny>,
 }
@@ -195,6 +198,10 @@ impl fmt::Display for Config {
                 &self.max_concurrent_requests.to_string(),
             ),
             ("Allow registration", &self.allow_registration.to_string()),
+            (
+                "Allow guest registration",
+                &self.allow_guest_registration.to_string(),
+            ),
             (
                 "Enabled lightning bolt",
                 &self.enable_lightning_bolt.to_string(),

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -295,6 +295,10 @@ impl Service {
         self.config.allow_registration
     }
 
+    pub fn allow_guest_registration(&self) -> bool {
+        self.config.allow_guest_registration
+    }
+
     pub fn allow_encryption(&self) -> bool {
         self.config.allow_encryption
     }


### PR DESCRIPTION
User reported in upstream Conduit that if you selfhost Element with guest access enabled and your default homeserver is Conduit, the *first* user or bot that visits that Element will automatically register a guest account via `/_matrix/client/v3/register?kind=guest` POST and a JSON body of simply the initial device display name; even if you have registration disabled with or without token registration.

Element sends `/_matrix/client/v3/register?kind=guest` automatically, but *any* Matrix homeserver running Conduit is vulnerable to *anyone* sending a POST request with URI `/_matrix/client/v3/register?kind=guest` and a JSON body with `initial_device_display_name` and it will create a guest account. There are definitely spambots doing this.

Conduit does not check if the first user is a guest so it will give that guest account admin. That guest account can then register an account manually via admin room and it now has a full proper account to use.

With these changes, we will forbid guest users from registering before a real user account has been granted admin.

Guest user registration now respects `allow_registration=false` when there's a token configured like it should have. If someone wants to allow guest registrations, a config option `allow_guest_registration` is added with default disabled.

All of this is arguably a security issue because accounts are still technically created (with just less privileges) and in the database, a guest user can escalate to a proper account and even be given admin as the guest account has admin room control if they did manage to get admin upon a new deployment, and Conduit has no rate limiting so someone can spam register accounts (potential denial of service vector).

Additionally add some logging for rejected guest/user registration attempts.