### PR TITLE
More misc things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,8 +2127,8 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.9.2"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+version = "0.9.4"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "assign",
  "js_int",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -2158,8 +2158,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.17.3"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+version = "0.17.4"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "assign",
  "bytes",
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "as_variant",
  "base64",
@@ -2204,8 +2204,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.27.9"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+version = "0.27.11"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "as_variant",
  "indexmap 2.0.0",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -2239,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.3"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "js_int",
  "thiserror",
@@ -2248,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "ruma-identity-service-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.14.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2301,7 +2301,7 @@ dependencies = [
 [[package]]
 name = "ruma-state-res"
 version = "0.10.0"
-source = "git+https://github.com/ruma/ruma?rev=5446ea979b314b90da1734f20efaff443d64f73d#5446ea979b314b90da1734f20efaff443d64f73d"
+source = "git+https://github.com/ruma/ruma?rev=9a5142052c808275f47613d4b66cb6c9fc286079#9a5142052c808275f47613d4b66cb6c9fc286079"
 dependencies = [
  "itertools",
  "js_int",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tower-http = { version = "0.4.4", features = ["add-extension", "cors", "sensitiv
 
 # Used for matrix spec type definitions and helpers
 #ruma = { version = "0.4.0", features = ["compat", "rand", "appservice-api-c", "client-api", "federation-api", "push-gateway-api-c", "state-res", "unstable-pre-spec", "unstable-exhaustive-types"] }
-ruma = { git = "https://github.com/ruma/ruma", rev = "5446ea979b314b90da1734f20efaff443d64f73d", features = ["compat", "rand", "appservice-api-c", "client-api", "federation-api", "push-gateway-api-c", "state-res", "unstable-msc2448", "unstable-msc3575", "unstable-exhaustive-types", "ring-compat", "unstable-unspecified", "unstable-msc3958", "unstable-msc2870", "unstable-msc3061", "unstable-extensible-events"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "9a5142052c808275f47613d4b66cb6c9fc286079", features = ["compat", "rand", "appservice-api-c", "client-api", "federation-api", "push-gateway-api-c", "state-res", "unstable-msc2448", "unstable-msc3575", "unstable-exhaustive-types", "ring-compat", "unstable-unspecified", "unstable-msc2870", "unstable-msc3061", "unstable-extensible-events"] }
 #ruma = { git = "https://github.com/timokoesters/ruma", rev = "4ec9c69bb7e09391add2382b3ebac97b6e8f4c64", features = ["compat", "rand", "appservice-api-c", "client-api", "federation-api", "push-gateway-api-c", "state-res", "unstable-msc2448", "unstable-msc3575", "unstable-exhaustive-types", "ring-compat", "unstable-unspecified" ] }
 #ruma = { path = "../ruma/crates/ruma", features = ["compat", "rand", "appservice-api-c", "client-api", "federation-api", "push-gateway-api-c", "state-res", "unstable-msc2448", "unstable-msc3575", "unstable-exhaustive-types", "ring-compat", "unstable-unspecified" ] }
 

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -12,12 +12,12 @@
 - Configurable RocksDB logging (`LOG` files) with proper defaults (rotate, max size, verbosity, etc) to stop LOG files from accumulating so much
 - Federated presence support and configurable local presence (via upstream MR)
 - Concurrency support for key fetching for faster remote room joins and room joins that will error less frequently (via upstream MR)
-- Experimental room version 11 suppor (via upstream MR)
+- Experimental room version 11 support (via upstream MR)
 - Enabled all non-officially-supported room versions as experimental so we can at least attempt to join them
 - Configurable guest registration including forbidding guest registrations if no admin user is created yet, respects allow registration setting, and an optional override setting with a default of no guest registrations allowed.
 - Explicit startup error/warning if your configuration allows open registration without a token or such like Synapse
 - Improved RocksDB defaults to use new features that help with performance significantly, uses settings tailored to SSDs, and a conduwuit setting to tell RocksDB to use settings that are tailored to HDDs or slow spinning rust storage.
-- Updated Ruma to almost latest version possible, and add some unstable MSCs (some still require an implementation though)
+- Updated Ruma to latest commit where possible, and add some unstable MSCs (some still require an implementation though)
 - conduwuit allows MXIDs with `+` in them (thanks to Ruma update)
 - Revamped admin room infrastructure and commands (via upstream MR)
 - Make spaces/hierarchy cache use cache_capacity_modifier instead of hardcoded small value
@@ -27,10 +27,14 @@
 - Add *optional* feature flag to enable zstd HTTP body compression
 - Add support for querying both Matrix SRV records, the deprecated `_matrix` record and `_matrix-fed` record if necessary
 - Add config option for device name federation with a privacy-friendly default (disabled)
-- Add config option for requiring authentication to the `/publicRooms` endpoint (room directory) with a default disabled for privacy
+- Add config option for requiring authentication to the `/publicRooms` endpoint (room directory) with a default enabled for privacy
 - Add config option for federating `/publicRooms` endpoint (room directory) to other servers with a default disabled for privacy
 - Add support for listening on a UNIX socket for performance and host security with proper default permissions (660)
 - Add missing `destination` key to all `X-Matrix` `Authorization` requests (spec compliance issue)
 - Fix spec compliance issue with servers being able to fetch remote user profiles over federation for users who don't belong to our server (`/_matrix/federation/v1/query/profile`)
 - Use aggressive build-time performance optimisations for release builds (1 codegen unit, no debug, fat LTO, etc, and optimise all crates with same)
 - Raise various hardcoded timeouts in codebase that were way too short, making some things like room joins and client bugs error less or none at all than they should
+- Add debug admin command to force update user device lists (could potentially resolve some E2EE flukes) (`ForceDeviceListUpdates`)
+- Declare various missing Matrix versions and features at `/_matrix/client/versions`
+- Add support for serving server and client well-known files from conduwuit using `well_known_client` and `well_known_server` options
+- Add non-standard sliding sync proxy health check (?) endpoint at `/client/server.json` that some clients such as Element Web query using the `well_known_client` or `well_known_server` config options

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -38,3 +38,4 @@
 - Declare various missing Matrix versions and features at `/_matrix/client/versions`
 - Add support for serving server and client well-known files from conduwuit using `well_known_client` and `well_known_server` options
 - Add non-standard sliding sync proxy health check (?) endpoint at `/client/server.json` that some clients such as Element Web query using the `well_known_client` or `well_known_server` config options
+- Send a User-Agent on all of our requests (`conduwuit/0.7.0-alpha+conduwuit-0.1.1`) which strangely was not done upstream since forever. Some providers consider no User-Agent suspicious and block said requests.

--- a/src/api/client_server/unversioned.rs
+++ b/src/api/client_server/unversioned.rs
@@ -20,14 +20,25 @@ pub async fn get_supported_versions_route(
 ) -> Result<get_supported_versions::Response> {
     let resp = get_supported_versions::Response {
         versions: vec![
+            "r0.0.1".to_owned(),
+            "r0.1.0".to_owned(),
+            "r0.2.0".to_owned(),
+            "r0.3.0".to_owned(),
+            "r0.4.0".to_owned(),
             "r0.5.0".to_owned(),
             "r0.6.0".to_owned(),
+            "r0.6.1".to_owned(),
             "v1.1".to_owned(),
             "v1.2".to_owned(),
             "v1.3".to_owned(),
             "v1.4".to_owned(),
+            "v1.5".to_owned(),
         ],
-        unstable_features: BTreeMap::from_iter([("org.matrix.e2e_cross_signing".to_owned(), true)]),
+        unstable_features: BTreeMap::from_iter([
+            ("org.matrix.e2e_cross_signing".to_owned(), true),
+            ("org.matrix.msc2836".to_owned(), true),
+            ("org.matrix.msc2946".to_owned(), true),
+        ]),
     };
 
     Ok(resp)

--- a/src/api/server_server.rs
+++ b/src/api/server_server.rs
@@ -2060,6 +2060,18 @@ pub async fn claim_keys_route(
     })
 }
 
+/// # `GET /.well-known/matrix/server`
+pub async fn well_known_server_route() -> Result<impl IntoResponse> {
+    let server_url = match services().globals.well_known_server() {
+        Some(url) => url.clone(),
+        None => return Err(Error::BadRequest(ErrorKind::NotFound, "Not found.")),
+    };
+
+    Ok(Json(serde_json::json!({
+        "m.server": server_url
+    })))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{add_port_to_hostname, get_ip_with_port, FedDest};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -70,6 +70,7 @@ pub struct Config {
     #[serde(default = "default_default_room_version")]
     pub default_room_version: RoomVersionId,
     pub well_known_client: Option<String>,
+    pub well_known_server: Option<String>,
     #[serde(default)]
     pub allow_jaeger: bool,
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ async fn main() {
     // * https://www.freedesktop.org/software/systemd/man/systemd.exec.html#id-1.12.2.1.17.6
     // * https://github.com/systemd/systemd/commit/0abf94923b4a95a7d89bc526efc84e7ca2b71741
     #[cfg(unix)]
-    maximize_fd_limit().expect("should be able to increase the soft limit to the hard limit");
+    maximize_fd_limit().expect("Unable to increase maximum soft and hard file descriptor limit");
 
     config.warn_deprecated();
     if config.is_dual_listening(raw_config) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,7 +514,18 @@ fn routes() -> Router {
             "/_matrix/client/v3/rooms/:room_id/initialSync",
             get(initial_sync),
         )
-        //.route("/client/server.json", get(syncv3_client_server_json))
+        .route(
+            "/client/server.json",
+            get(client_server::syncv3_client_server_json),
+        )
+        .route(
+            "/.well-known/matrix/client",
+            get(client_server::well_known_client_route),
+        )
+        .route(
+            "/.well-known/matrix/server",
+            get(server_server::well_known_server_route),
+        )
         .route("/", get(it_works))
         .fallback(not_found)
 }
@@ -571,19 +582,6 @@ async fn initial_sync(_uri: Uri) -> impl IntoResponse {
 async fn it_works() -> &'static str {
     "hewwo from conduwuit woof!"
 }
-
-/*
-// TODO: add /client/server.json support by querying our client well-known for the true matrix homeserver URL
-async fn syncv3_client_server_json(uri: Uri) -> impl IntoResponse {
-    let server_name = services().globals.server_name().to_string();
-    let response = services().globals.default_client().get(&format!("https://{server_name"))
-    let server = uri.scheme_str().unwrap_or("https").to_owned() + "://" + uri.host().unwrap();
-    let version = format!("cowonduit {}", env!("CARGO_PKG_VERSION").to_owned());
-    let body = format!("{{\"server\":\"{server}\",\"version\":\"{version}\"}}");
-
-    Json(body)
-}
-*/
 
 trait RouterExt {
     fn ruma_route<H, T>(self, handler: H) -> Self

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -542,7 +542,12 @@ fn reqwest_client_builder(config: &Config) -> Result<reqwest::ClientBuilder> {
     let mut reqwest_client_builder = reqwest::Client::builder()
         .pool_max_idle_per_host(0)
         .connect_timeout(Duration::from_secs(60))
-        .timeout(Duration::from_secs(60 * 5));
+        .timeout(Duration::from_secs(60 * 5))
+        .user_agent(concat!(
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION")
+        ));
 
     if let Some(proxy) = config.proxy.to_proxy()? {
         reqwest_client_builder = reqwest_client_builder.proxy(proxy);

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -509,6 +509,10 @@ impl Service<'_> {
         &self.config.well_known_client
     }
 
+    pub fn well_known_server(&self) -> &Option<String> {
+        &self.config.well_known_server
+    }
+
     pub fn unix_socket_path(&self) -> &Option<PathBuf> {
         &self.config.unix_socket_path
     }

--- a/src/service/rooms/state_accessor/mod.rs
+++ b/src/service/rooms/state_accessor/mod.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 pub use data::Data;
+use js_option::JsOption;
 use lru_cache::LruCache;
 use ruma::{
     events::{
@@ -290,12 +291,12 @@ impl Service {
             })
     }
 
-    pub fn get_avatar(&self, room_id: &RoomId) -> Result<Option<RoomAvatarEventContent>> {
+    pub fn get_avatar(&self, room_id: &RoomId) -> Result<JsOption<RoomAvatarEventContent>> {
         services()
             .rooms
             .state_accessor
             .room_state_get(room_id, &StateEventType::RoomAvatar, "")?
-            .map_or(Ok(None), |s| {
+            .map_or(Ok(JsOption::Undefined), |s| {
                 serde_json::from_str(s.content.get())
                     .map_err(|_| Error::bad_database("Invalid room avatar event in database."))
             })


### PR DESCRIPTION
Bump ruma to latest commit, ability to serve client/server well-knowns from conduwuit, ability to server `/client/server.json` from conduwuit which is just a sliding sync proxy non-standard health check endpoint that Element Web uses, declare support for some Matrix versions that we should have been declaring (compared ours with Dendrite and Synapse just to be safe), and send a User-Agent on all of our requests which Conduit impressively was not doing this entire time.