### PR TITLE
17 01 2023

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -53,3 +53,4 @@
 - Generate passwords with 25 characters instead of 15
 - Add missing `reason` field to user ban events (`/ban`)
 - For all [`/report`](https://spec.matrix.org/v1.9/client-server-api/#post_matrixclientv3roomsroomidreporteventid) requests: check if the reported event ID belongs to the reported room ID, raise report reasoning character limit to 750, fix broken formatting, make a small delayed random response per spec suggestion on privacy, and check if the sender user is in the reported room.
+- Support blocking servers from downloading remote media from

--- a/src/api/client_server/media.rs
+++ b/src/api/client_server/media.rs
@@ -92,7 +92,7 @@ pub async fn get_remote_content(
     Ok(content_response)
 }
 
-/// # `GET /_matrix/media/r0/download/{serverName}/{mediaId}`
+/// # `GET /_matrix/media/v3/download/{serverName}/{mediaId}`
 ///
 /// Load media from our server or over federation.
 ///
@@ -123,7 +123,7 @@ pub async fn get_content_route(
     }
 }
 
-/// # `GET /_matrix/media/r0/download/{serverName}/{mediaId}/{fileName}`
+/// # `GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`
 ///
 /// Load media from our server or over federation, permitting desired filename.
 ///
@@ -158,7 +158,7 @@ pub async fn get_content_as_filename_route(
     }
 }
 
-/// # `GET /_matrix/media/r0/thumbnail/{serverName}/{mediaId}`
+/// # `GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`
 ///
 /// Load media thumbnail from our server or over federation.
 ///

--- a/src/api/client_server/message.rs
+++ b/src/api/client_server/message.rs
@@ -14,7 +14,7 @@ use std::{
     sync::Arc,
 };
 
-/// # `PUT /_matrix/client/r0/rooms/{roomId}/send/{eventType}/{txnId}`
+/// # `PUT /_matrix/client/v3/rooms/{roomId}/send/{eventType}/{txnId}`
 ///
 /// Send a message event into the room.
 ///

--- a/src/api/server_server.rs
+++ b/src/api/server_server.rs
@@ -1822,8 +1822,10 @@ pub async fn create_invite_route(
         ));
     }
 
-    let mut signed_event = utils::to_canonical_object(&body.event)
-        .map_err(|_| Error::BadRequest(ErrorKind::InvalidParam, "Invite event is invalid."))?;
+    let mut signed_event = utils::to_canonical_object(&body.event).map_err(|e| {
+        error!("Failed to convert invite event to canonical JSON: {}", e);
+        Error::BadRequest(ErrorKind::InvalidParam, "Invite event is invalid.")
+    })?;
 
     ruma::signatures::hash_and_sign_event(
         services().globals.server_name().as_str(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,6 +128,9 @@ pub struct Config {
     #[serde(default)]
     pub allow_guest_registration: bool,
 
+    #[serde(default = "Vec::new")]
+    pub prevent_media_downloads_from: Vec<OwnedServerName>,
+
     #[serde(flatten)]
     pub catchall: BTreeMap<String, IgnoredAny>,
 }
@@ -305,6 +308,13 @@ impl fmt::Display for Config {
                 "RocksDB database optimize for spinning disks",
                 &self.rocksdb_optimize_for_spinning_disks.to_string(),
             ),
+            ("Prevent Media Downloads From", {
+                let mut lst = vec![];
+                for domain in &self.prevent_media_downloads_from {
+                    lst.push(domain.host());
+                }
+                &lst.join(", ")
+            }),
         ];
 
         let mut msg: String = "Active config values:\n\n".to_owned();

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -423,6 +423,10 @@ impl Service<'_> {
         self.config.rocksdb_optimize_for_spinning_disks
     }
 
+    pub fn prevent_media_downloads_from(&self) -> &[OwnedServerName] {
+        &self.config.prevent_media_downloads_from
+    }
+
     pub fn supported_room_versions(&self) -> Vec<RoomVersionId> {
         let mut room_versions: Vec<RoomVersionId> = vec![];
         room_versions.extend(self.stable_room_versions.clone());

--- a/src/service/rooms/timeline/mod.rs
+++ b/src/service/rooms/timeline/mod.rs
@@ -802,7 +802,7 @@ impl Service {
             |k, s| auth_events.get(&(k.clone(), s.to_owned())),
         )
         .map_err(|e| {
-            error!("{:?}", e);
+            error!("Auth check for PDU {:?} failed: {:?}", &pdu, e);
             Error::bad_database("Auth check failed.")
         })?;
 

--- a/src/service/rooms/timeline/mod.rs
+++ b/src/service/rooms/timeline/mod.rs
@@ -814,8 +814,10 @@ impl Service {
         }
 
         // Hash and sign
-        let mut pdu_json =
-            utils::to_canonical_object(&pdu).expect("event is valid, we just created it");
+        let mut pdu_json = utils::to_canonical_object(&pdu).map_err(|e| {
+            error!("Failed to convert PDU {:?} to canonical JSON: {}", &pdu, e);
+            Error::bad_database("Failed to convert PDU to canonical JSON.")
+        })?;
 
         pdu_json.remove("event_id");
 


### PR DESCRIPTION
Solves https://github.com/girlbossceo/conduwuit/issues/98 and https://github.com/girlbossceo/conduwuit/issues/100

As usual, the denial of service was just dumb unwrapping/expecting. Replacing it with a proper error would prevent crashing, who would have known? Do I look crazy for wanting to return proper errors instead of panicking and unwrapping everything or something?

Also adds support for blocking servers from fetching remote media from. Config option is `prevent_media_downloads_from = ["server.name1", "server.name2"]`

Technically you can add yourself into it, but it would be a no-op as there's code that prevents sending federation requests to ourselves (assuming that isn't broken), and a check if the requested media belongs to our server before we try fetching over federation. Don't think I'll bother fixing that for those reasons.

```
2024-01-18T04:39:21.595817Z  INFO http_request{path=/_matrix/media/v3/thumbnail/:server_name/:media_id}: conduit::api::client_server::media: Received request for remote media `mxc://puppygock.gay/vUGybFHN8LHNx7LOOxGT1hPQcgBUpKKe` but server is in our media server blocklist. Returning 404.
2024-01-18T04:39:21.595837Z  INFO http_request{path=/_matrix/media/v3/thumbnail/:server_name/:media_id}: conduit::utils::error: Returning an error: 404 Not Found: M_NOT_FOUND: Media not found.
```