### PR TITLE
bump nix cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
 
       - name: Pop/push Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v2
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Configure `nix-direnv`
         run: |


### PR DESCRIPTION
Fix nodejs v16 incompatible/deprecation
Per recommended usage: https://github.com/DeterminateSystems/magic-nix-cache-action#usage