### PR TITLE
GitHub Actions CI port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,25 @@ jobs:
           name: static-aarch64-unknown-linux-musl
           path: result/bin/conduit
           if-no-files-found: error
+
+      - name: Build oci-image-x86_64-unknown-linux-gnu
+        run: |
+          ./bin/nix-build-and-cache .#oci-image
+
+      - name: Upload artifact oci-image-x86_64-unknown-linux-gnu
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-image-x86_64-unknown-linux-gnu
+          path: result
+          if-no-files-found: error
+
+      - name: Build oci-image-aarch64-unknown-linux-musl
+        run: |
+          ./bin/nix-build-and-cache .#oci-image-aarch64-unknown-linux-musl
+
+      - name: Upload artifact oci-image-aarch64-unknown-linux-musl
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-image-aarch64-unknown-linux-musl
+          path: result
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build oci-image-x86_64-unknown-linux-gnu
         run: |
           ./bin/nix-build-and-cache .#oci-image
-          cp result oci-image.tar.gz
+          cp -f result oci-image.tar.gz
 
       - name: Upload artifact oci-image-x86_64-unknown-linux-gnu
         uses: actions/upload-artifact@v4
@@ -108,7 +108,7 @@ jobs:
       - name: Build oci-image-aarch64-unknown-linux-musl
         run: |
           ./bin/nix-build-and-cache .#oci-image-aarch64-unknown-linux-musl
-          cp result oci-image.tar.gz
+          cp -f result oci-image.tar.gz
 
       - name: Upload artifact oci-image-aarch64-unknown-linux-musl
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Sync repository
         uses: actions/checkout@v4
 
-      - name: Uninstall obstructive tools
-        run: rm -rf "$HOME/.rustup" "$HOME/.cargo"
-
       - name: Install Nix (with flakes and nix-command enabled)
         uses: cachix/install-nix-action@v25
         with:
@@ -129,16 +126,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: deb-x86_64-unknown-linux-gnu
-          path: target/debian/*.deb
-          if-no-files-found: error
-
-      - name: Build deb-aarch64-unknown-linux-gnu
-        run: |
-          cargo deb --target=aarch64-unknown-linux-gnu
-
-      - name: Upload artifact deb-aarch64-unknown-linux-gnu
-        uses: actions/upload-artifact@v4
-        with:
-          name: deb-aarch64-unknown-linux-gnu
           path: target/debian/*.deb
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           echo 'source $HOME/.nix-profile/share/nix-direnv/direnvrc' > "$HOME/.direnvrc"
 
       - name: Install `direnv` and `nix-direnv`
-        run: nix-env -f "<nixpkgs>" -i direnv -i nix-direnv
+        run: nix-env -f "<nixpkgs>" -iA direnv -iA nix-direnv
 
       - name: Pop/push downloaded crate cache
         uses: actions/cache@v4
@@ -73,23 +73,21 @@ jobs:
       - name: Build static-x86_64-unknown-linux-musl
         run: |
           ./bin/nix-build-and-cache .#static-x86_64-unknown-linux-musl
-          cp result/bin/conduit conduit
 
       - name: Upload artifact static-x86_64-unknown-linux-musl
         uses: actions/upload-artifact@v4
         with:
           name: static-x86_64-unknown-linux-musl
-          path: conduit
+          path: result/bin/conduit
           if-no-files-found: error
 
       - name: Build static-aarch64-unknown-linux-musl
         run: |
           ./bin/nix-build-and-cache .#static-aarch64-unknown-linux-musl
-          cp result/bin/conduit conduit
 
       - name: Upload artifact static-aarch64-unknown-linux-musl
         uses: actions/upload-artifact@v4
         with:
           name: static-aarch64-unknown-linux-musl
-          path: conduit
+          path: result/bin/conduit
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,22 +71,24 @@ jobs:
           direnv exec . engage
 
       - name: Build static-x86_64-unknown-linux-musl
-        run: ./bin/nix-build-and-cache .#static-x86_64-unknown-linux-musl
+        run: |
+          ./bin/nix-build-and-cache .#static-x86_64-unknown-linux-musl
+          cp result/bin/conduit conduit
 
       - name: Upload artifact static-x86_64-unknown-linux-musl
         uses: actions/upload-artifact@v4
-        run: cp result/bin/conduit conduit
         with:
           name: static-x86_64-unknown-linux-musl
           path: conduit
           if-no-files-found: error
 
       - name: Build static-aarch64-unknown-linux-musl
-        run: ./bin/nix-build-and-cache .#static-aarch64-unknown-linux-musl
+        run: |
+          ./bin/nix-build-and-cache .#static-aarch64-unknown-linux-musl
+          cp result/bin/conduit conduit
 
       - name: Upload artifact static-aarch64-unknown-linux-musl
         uses: actions/upload-artifact@v4
-        run: cp result/bin/conduit conduit
         with:
           name: static-aarch64-unknown-linux-musl
           path: conduit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,16 @@ jobs:
           if-no-files-found: error
           # don't compress again
           compression-level: 0
+
+      - name: Build deb-x86_64-unknown-linux-gnu
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev
+          cargo install cargo-deb
+          cargo deb
+
+      - name: Upload artifact deb-x86_64-unknown-linux-gnu
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-x86_64-unknown-linux-gnu
+          path: target/debian/*.deb
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
-name: CI
+name: CI and Artifacts
 
 on:
   pull_request:
   push:
     branches:
       - main
+      - gh-actions-port
 
 env:
   # Required to make some things output color
@@ -12,7 +13,7 @@ env:
 
 jobs:
   ci:
-    name: CI
+    name: CI and Artifacts
 
     runs-on: ubuntu-latest
 
@@ -30,8 +31,13 @@ jobs:
 
           # Add the `nix-community` cachix to speed up things that leverage it
           extra_nix_config: |
+            experimental-features = nix-command flakes
             extra-substituters = https://nix-community.cachix.org
             extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+            extra-substituters = https://crane.cachix.org
+            extra-trusted-public-keys = crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk=
+            extra-substituters = https://nix.computer.surgery/conduit
+            extra-trusted-public-keys = conduit:ZGAf6P6LhNvnoJJ3Me3PRg7tlLSrPxcQ2RiE5LIppjo=
 
       - name: Pop/push Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@main
@@ -63,3 +69,25 @@ jobs:
         run: |
           direnv allow
           direnv exec . engage
+
+      - name: Build static-x86_64-unknown-linux-musl
+        run: ./bin/nix-build-and-cache .#static-x86_64-unknown-linux-musl
+
+      - name: Upload artifact static-x86_64-unknown-linux-musl
+        uses: actions/upload-artifact@v4
+        run: cp result/bin/conduit conduit
+        with:
+          name: static-x86_64-unknown-linux-musl
+          path: conduit
+          if-no-files-found: error
+
+      - name: Build static-aarch64-unknown-linux-musl
+        run: ./bin/nix-build-and-cache .#static-aarch64-unknown-linux-musl
+
+      - name: Upload artifact static-aarch64-unknown-linux-musl
+        uses: actions/upload-artifact@v4
+        run: cp result/bin/conduit conduit
+        with:
+          name: static-aarch64-unknown-linux-musl
+          path: conduit
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,21 +95,26 @@ jobs:
       - name: Build oci-image-x86_64-unknown-linux-gnu
         run: |
           ./bin/nix-build-and-cache .#oci-image
+          cp result oci-image.tar.gz
 
       - name: Upload artifact oci-image-x86_64-unknown-linux-gnu
         uses: actions/upload-artifact@v4
         with:
           name: oci-image-x86_64-unknown-linux-gnu
-          path: result
-          if-no-files-found: error
+          path: oci-image.tar.gz
+          # don't compress again
+          compression-level: 0
 
       - name: Build oci-image-aarch64-unknown-linux-musl
         run: |
           ./bin/nix-build-and-cache .#oci-image-aarch64-unknown-linux-musl
+          cp result oci-image.tar.gz
 
       - name: Upload artifact oci-image-aarch64-unknown-linux-musl
         uses: actions/upload-artifact@v4
         with:
           name: oci-image-aarch64-unknown-linux-musl
-          path: result
+          path: oci-image.tar.gz
           if-no-files-found: error
+          # don't compress again
+          compression-level: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,14 @@ jobs:
           name: deb-x86_64-unknown-linux-gnu
           path: target/debian/*.deb
           if-no-files-found: error
+
+      - name: Build deb-aarch64-unknown-linux-gnu
+        run: |
+          cargo deb --target=aarch64-unknown-linux-gnu
+
+      - name: Upload artifact deb-aarch64-unknown-linux-gnu
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-aarch64-unknown-linux-gnu
+          path: target/debian/*.deb
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,26 +92,26 @@ jobs:
       - name: Build oci-image-x86_64-unknown-linux-gnu
         run: |
           ./bin/nix-build-and-cache .#oci-image
-          cp -f result oci-image.tar.gz
+          cp -f result oci-image-amd64.tar.gz
 
       - name: Upload artifact oci-image-x86_64-unknown-linux-gnu
         uses: actions/upload-artifact@v4
         with:
           name: oci-image-x86_64-unknown-linux-gnu
-          path: oci-image.tar.gz
+          path: oci-image-amd64.tar.gz
           # don't compress again
           compression-level: 0
 
       - name: Build oci-image-aarch64-unknown-linux-musl
         run: |
           ./bin/nix-build-and-cache .#oci-image-aarch64-unknown-linux-musl
-          cp -f result oci-image.tar.gz
+          cp -f result oci-image-arm64v8.tar.gz
 
       - name: Upload artifact oci-image-aarch64-unknown-linux-musl
         uses: actions/upload-artifact@v4
         with:
           name: oci-image-aarch64-unknown-linux-musl
-          path: oci-image.tar.gz
+          path: oci-image-arm64v8.tar.gz
           if-no-files-found: error
           # don't compress again
           compression-level: 0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,9 @@ static:aarch64-unknown-linux-musl:
     paths:
       - conduit
 
+# Note that although we have an `oci-image-x86_64-unknown-linux-musl` output,
+# we don't build it because it would be largely redundant to this one since it's
+# all containerized anyway.
 oci-image:x86_64-unknown-linux-gnu:
   stage: artifacts
   image: nixos/nix:2.19.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,11 +104,11 @@ oci-image:aarch64-unknown-linux-musl:
     - cp result oci-image.tar.gz
   artifacts:
     paths:
-      - docker-image.tar.gz
+      - oci-image.tar.gz
 
 debian:x86_64-unknown-linux-gnu:
   stage: artifacts
-    # See also `rust-toolchain.toml`
+  # See also `rust-toolchain.toml`
   image: rust:1.75.0
   script:
     - apt-get update && apt-get install -y --no-install-recommends libclang-dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - ci
   - artifacts
+  - publish
 
 variables:
   # Makes some things print in color
@@ -84,10 +85,10 @@ oci-image:x86_64-unknown-linux-gnu:
     - ./bin/nix-build-and-cache .#oci-image
 
     # Make the output less difficult to find
-    - cp result oci-image.tar.gz
+    - cp result oci-image-amd64.tar.gz
   artifacts:
     paths:
-      - oci-image.tar.gz
+      - oci-image-amd64.tar.gz
 
 oci-image:aarch64-unknown-linux-musl:
   stage: artifacts
@@ -101,10 +102,10 @@ oci-image:aarch64-unknown-linux-musl:
     - ./bin/nix-build-and-cache .#oci-image-aarch64-unknown-linux-musl
 
     # Make the output less difficult to find
-    - cp result oci-image.tar.gz
+    - cp result oci-image-arm64v8.tar.gz
   artifacts:
     paths:
-      - oci-image.tar.gz
+      - oci-image-arm64v8.tar.gz
 
 debian:x86_64-unknown-linux-gnu:
   stage: artifacts
@@ -126,3 +127,43 @@ debian:x86_64-unknown-linux-gnu:
       - target
       - .gitlab-ci.d
 
+docker-publish:
+  stage: publish
+  image: docker:25.0.0
+  services:
+    - docker:25.0.0-dind
+  variables:
+    IMAGE_NAME: $CI_REGISTRY_IMAGE/matrix-conduit
+    IMAGE_SUFFIX_AMD64: amd64
+    IMAGE_SUFFIX_ARM64V8: arm64v8
+  before_script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  script:
+    - docker load -i oci-image-amd64.tar.gz
+    - IMAGE_ID_AMD64=$(docker images -q conduit:next)
+    - docker load -i oci-image-arm64v8.tar.gz
+    - IMAGE_ID_ARM64V8=$(docker images -q conduit:next)
+    # Tag and push the architecture specific images
+    - docker tag $IMAGE_ID_AMD64 $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_AMD64
+    - docker tag $IMAGE_ID_ARM64V8 $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_ARM64V8
+    - docker push $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_AMD64
+    - docker push $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_ARM64V8
+    # Tag the multi-arch image
+    - docker manifest create $IMAGE_NAME:$CI_COMMIT_SHA --amend $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_AMD64 --amend $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_ARM64V8
+    - docker manifest push $IMAGE_NAME:$CI_COMMIT_SHA
+    # Tag and push the git ref
+    - docker manifest create $IMAGE_NAME:$CI_COMMIT_REF_NAME --amend $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_AMD64 --amend $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_ARM64V8
+    - docker manifest push $IMAGE_NAME:$CI_COMMIT_REF_NAME
+    # Tag git tags as 'latest'
+    - |
+      if [[ -n "$CI_COMMIT_TAG" ]]; then
+        docker manifest create $IMAGE_NAME:latest --amend $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_AMD64 --amend $IMAGE_NAME:$CI_COMMIT_SHA-$IMAGE_SUFFIX_ARM64V8
+        docker manifest push $IMAGE_NAME:latest
+      fi
+  dependencies:
+    - oci-image:x86_64-unknown-linux-gnu
+    - oci-image:aarch64-unknown-linux-musl
+  only:
+    - next
+    - master
+    - tags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,16 +218,17 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.69.2"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c69fae65a523209d34240b60abe0c42d33d1045d445c0839d8a4894a736e2d"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1246,8 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=1fb26dd5dc363c9fded526bac45366a436fc50a9#1fb26dd5dc363c9fded526bac45366a436fc50a9"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1784,6 +1786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2004,8 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.21.0"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=1fb26dd5dc363c9fded526bac45366a436fc50a9#1fb26dd5dc363c9fded526bac45366a436fc50a9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "arc-swap"
@@ -82,9 +82,9 @@ checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
 
 [[package]]
 name = "async-compression"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
+checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
  "futures-core",
  "memchr",
@@ -275,9 +275,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "byteorder"
@@ -668,9 +668,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209098dd6dfc4445aa6111f0e98653ac323eaa4dfd212c9ca3931bf9955c31bd"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
 ]
@@ -837,9 +837,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -905,9 +905,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1274,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1708,18 +1708,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "platforms"
@@ -1797,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
  "toml_datetime",
  "toml_edit",
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1900,7 +1900,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.4",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -1915,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2351,18 +2351,18 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224e6a14f315852940f3ec103125aa6482f0e224732ed91ed3330ed633077c34"
+checksum = "20e1066e1cfa6692a722cf40386a2caec36da5ddc4a2c16df592f0f609677e8c"
 dependencies = [
  "form_urlencoded",
  "indexmap",
@@ -2384,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2481,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -3068,18 +3068,18 @@ checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
 name = "uncased"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -3127,9 +3127,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]
@@ -3255,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "widestring"
@@ -3427,9 +3427,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,13 +132,12 @@ path = "src/lib.rs"
 
 [package.metadata.deb]
 name = "matrix-conduit"
-maintainer = "Paul van Tilburg <paul@luon.net>"
-copyright = "2020, Timo Kösters <timo@koesters.xyz>"
+maintainer = "strawberry <strawberry@puppygock.gay>"
+copyright = "2024, Timo Kösters <timo@koesters.xyz>"
 license-file = ["LICENSE", "3"]
 depends = "$auto, ca-certificates"
 extended-description = """\
-A fast Matrix homeserver that is optimized for smaller, personal servers, \
-instead of a server that has high scalability."""
+a cool fork of Conduit, a Matrix homeserver written in Rust"""
 section = "net"
 priority = "optional"
 assets = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ threadpool = "1.8.1"
 # Used for ruma wrapper
 serde_html_form = "0.2.3"
 
-rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "1fb26dd5dc363c9fded526bac45366a436fc50a9", default-features = false, features = ["multi-threaded-cf", "snappy", "lz4", "zstd"], optional = true }
+rocksdb = { version = "0.21.0", default-features = true, features = ["multi-threaded-cf", "zstd"], optional = true }
 
 thread_local = "1.1.7"
 # used for TURN server authentication

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -9,10 +9,39 @@
 
 ## Installing conduwuit
 
-Although you might be able to compile conduwuit for Windows, we only support running it on a Linux server. We therefore
-only offer Linux binaries.
+You may simply download the binary that fits your machine. Run `uname -m` to see what you need. Now copy the appropriate URL:
 
-conduwuit does not offer prebuilt binaries for now. Building it yourself is the only supported method.
+**Stable versions:**
+
+| CPU Architecture                            | Download stable version                                         |
+| ------------------------------------------- | --------------------------------------------------------------- |
+| x84_64 / amd64 (Most servers and computers) | [Binary][x84_64-glibc-master] / [.deb][x84_64-glibc-master-deb] |
+| armv7 (e.g. Raspberry Pi by default)        | [Binary][armv7-glibc-master] / [.deb][armv7-glibc-master-deb]   |
+| armv8 / aarch64                             | [Binary][armv8-glibc-master] / [.deb][armv8-glibc-master-deb]   |
+
+[x84_64-glibc-master]: https://gitlab.com/famedly/conduit/-/jobs/artifacts/master/raw/build-output/linux_amd64/conduit?job=docker:master
+[armv7-glibc-master]: https://gitlab.com/famedly/conduit/-/jobs/artifacts/master/raw/build-output/linux_arm_v7/conduit?job=docker:master
+[armv8-glibc-master]: https://gitlab.com/famedly/conduit/-/jobs/artifacts/master/raw/build-output/linux_arm64/conduit?job=docker:master
+[x84_64-glibc-master-deb]: https://gitlab.com/famedly/conduit/-/jobs/artifacts/master/raw/build-output/linux_amd64/conduit.deb?job=docker:master
+[armv7-glibc-master-deb]: https://gitlab.com/famedly/conduit/-/jobs/artifacts/master/raw/build-output/linux_arm_v7/conduit.deb?job=docker:master
+[armv8-glibc-master-deb]: https://gitlab.com/famedly/conduit/-/jobs/artifacts/master/raw/build-output/linux_arm64/conduit.deb?job=docker:master
+
+**Latest versions:**
+
+| Target | Type | Download |
+|-|-|-|
+| `x86_64-unknown-linux-gnu` | Dynamically linked Debian package | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/conduit.deb?job=debian:x86_64-unknown-linux-gnu) |
+| `x86_64-unknown-linux-musl` | Statically linked binary | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/conduit?job=static:x86_64-unknown-linux-musl) |
+| `aarch64-unknown-linux-musl` | Statically linked binary | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/conduit?job=static:aarch64-unknown-linux-musl) |
+| `x86_64-unknown-linux-musl` | OCI image | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/oci-image.tar.gz?job=oci-image:x86_64-unknown-linux-musl) |
+| `aarch64-unknown-linux-musl` | OCI image | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/oci-image.tar.gz?job=oci-image:aarch64-unknown-linux-musl) |
+
+```bash
+$ sudo wget -O /usr/local/bin/matrix-conduit <url>
+$ sudo chmod +x /usr/local/bin/matrix-conduit
+```
+
+Alternatively, you may compile the binary yourself. First, install any dependencies:
 
 ```bash
 # Debian

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -33,8 +33,8 @@ You may simply download the binary that fits your machine. Run `uname -m` to see
 | `x86_64-unknown-linux-gnu` | Dynamically linked Debian package | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/conduit.deb?job=debian:x86_64-unknown-linux-gnu) |
 | `x86_64-unknown-linux-musl` | Statically linked binary | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/conduit?job=static:x86_64-unknown-linux-musl) |
 | `aarch64-unknown-linux-musl` | Statically linked binary | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/conduit?job=static:aarch64-unknown-linux-musl) |
-| `x86_64-unknown-linux-musl` | OCI image | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/oci-image.tar.gz?job=oci-image:x86_64-unknown-linux-musl) |
-| `aarch64-unknown-linux-musl` | OCI image | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/oci-image.tar.gz?job=oci-image:aarch64-unknown-linux-musl) |
+| `x86_64-unknown-linux-musl` | OCI image | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/oci-image-amd64.tar.gz?job=oci-image:x86_64-unknown-linux-musl) |
+| `aarch64-unknown-linux-musl` | OCI image | [link](https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/oci-image-arm64v8.tar.gz?job=oci-image:aarch64-unknown-linux-musl) |
 
 ```bash
 $ sudo wget -O /usr/local/bin/matrix-conduit <url>

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -1,12 +1,12 @@
 ### list of features, bug fixes, etc that conduwuit does that upstream does not:
 
+- GitLab CI ported to GitHub Actions
 - Fixed every single clippy (default lints) and rustc warnings, including some that were performance related or potential safety issues / unsoundness
 - Has dependabot and significantly updates all dependencies possible
 - Uses proper argon2 crate instead of questionable rust-argon2 crate
 - Improved and cleaned up logging (less noisy dead server logging, registration attempts, more useful troubleshooting logging, etc)
 - Attempts and interest in removing extreme and unnecessary panics/unwraps/expects that can lead to denial of service or such (upstream and upstream contributors want this unusual behaviour for some reason)
 - Merged and cleaned up upstream MRs that have been sitting for 6-12 months
-- Using latest rust-rocksdb git for the latest RocksDB release which has various fixes, features, improvements, etc, including some regarding database corruption.
 - Configurable RocksDB logging (`LOG` files) with proper defaults (rotate, max size, verbosity, etc) to stop LOG files from accumulating so much
 - Federated presence support and configurable local presence (via upstream MR)
 - Concurrency support for key fetching for faster remote room joins and room joins that will error less frequently (via upstream MR)

--- a/bin/complement
+++ b/bin/complement
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Path to Complement's source code
+COMPLEMENT_SRC="$1"
+
+# A `.jsonl` file to write test logs to
+LOG_FILE="$2"
+
+# A `.jsonl` file to write test results to
+RESULTS_FILE="$3"
+
+OCI_IMAGE="complement-conduit:dev"
+
+env \
+    -C "$(git rev-parse --show-toplevel)" \
+    docker build \
+        --tag "$OCI_IMAGE" \
+        --file complement/Dockerfile \
+        .
+
+# It's okay (likely, even) that `go test` exits nonzero
+set +o pipefail
+env \
+    -C "$COMPLEMENT_SRC" \
+    COMPLEMENT_BASE_IMAGE="$OCI_IMAGE" \
+    go test -json ./tests | tee "$LOG_FILE"
+set -o pipefail
+
+# Post-process the results into an easy-to-compare format
+cat "$LOG_FILE" | jq -c '
+    select(
+        (.Action == "pass" or .Action == "fail" or .Action == "skip")
+        and .Test != null
+    ) | {Action: .Action, Test: .Test}
+    ' | sort > "$RESULTS_FILE"

--- a/bin/nix-build-and-cache
+++ b/bin/nix-build-and-cache
@@ -6,7 +6,7 @@ set -euo pipefail
 INSTALLABLE="$1"
 
 # Build the installable and forward any other arguments too
-nix build "$@"
+nix build -L "$@"
 
 if [ ! -z ${ATTIC_TOKEN+x} ]; then
 

--- a/complement/Dockerfile
+++ b/complement/Dockerfile
@@ -1,26 +1,30 @@
-# For use in our CI only. This requires a build artifact created by a previous run pipline stage to be placed in cached_target/release/conduit
-FROM registry.gitlab.com/jfowl/conduit-containers/rust-with-tools:commit-16a08e9b as builder
-#FROM rust:latest as builder
+FROM rust:1.75.0
 
 WORKDIR /workdir
 
-ARG RUSTC_WRAPPER
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-ARG SCCACHE_BUCKET
-ARG SCCACHE_ENDPOINT
-ARG SCCACHE_S3_USE_SSL
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libclang-dev
 
-COPY . .
-RUN mkdir -p target/release
-RUN test -e cached_target/release/conduit && cp cached_target/release/conduit target/release/conduit || cargo build --release
-
-## Actual image
-FROM debian:bullseye
-WORKDIR /workdir
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY src src
+RUN cargo build --release \
+    && mv target/release/conduit conduit \
+    && rm -rf target
 
 # Install caddy
-RUN apt-get update && apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-testing-archive-keyring.gpg && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-testing.list && apt-get update && apt-get install -y caddy
+RUN apt-get update \
+    && apt-get install -y \
+    debian-keyring \
+    debian-archive-keyring \
+    apt-transport-https \
+    curl \
+    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-testing-archive-keyring.gpg \
+    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' \
+    | tee /etc/apt/sources.list.d/caddy-testing.list \
+    && apt-get update \
+    && apt-get install -y caddy
 
 COPY conduit-example.toml conduit.toml
 COPY complement/caddy.json caddy.json
@@ -29,15 +33,8 @@ ENV SERVER_NAME=localhost
 ENV CONDUIT_CONFIG=/workdir/conduit.toml
 
 RUN sed -i "s/port = 6167/port = 8008/g" conduit.toml
-RUN echo "allow_federation = true" >> conduit.toml
-RUN echo "allow_check_for_updates = true" >> conduit.toml
-RUN echo "allow_encryption = true" >> conduit.toml
-RUN echo "allow_registration = true" >> conduit.toml
-RUN echo "log = \"warn,_=off\"" >> conduit.toml
+RUN echo "log = \"warn,_=off,sled=off\"" >> conduit.toml
 RUN sed -i "s/address = \"127.0.0.1\"/address = \"0.0.0.0\"/g" conduit.toml
-
-COPY --from=builder /workdir/target/release/conduit /workdir/conduit
-RUN chmod +x /workdir/conduit
 
 EXPOSE 8008 8448
 
@@ -46,3 +43,4 @@ CMD uname -a && \
     sed -i "s/your.server.name/${SERVER_NAME}/g" caddy.json && \
     caddy start --config caddy.json > /dev/null && \
     /workdir/conduit
+

--- a/complement/README.md
+++ b/complement/README.md
@@ -1,13 +1,12 @@
-# Running Conduit on Complement
+# Complement
 
-This assumes that you're familiar with complement, if not, please readme
-[their readme](https://github.com/matrix-org/complement#running).
+## What's that?
 
-Complement works with "base images", this directory (and Dockerfile) helps build the conduit complement-ready docker
-image.
+Have a look at [its repository](https://github.com/matrix-org/complement).
 
-To build, `cd` to the base directory of the workspace, and run this:
+## How do I use it with Conduit?
 
-`docker build -t complement-conduit:dev -f complement/Dockerfile .`
+The script at [`../bin/complement`](../bin/complement) has automation for this.
+It takes a few command line arguments, you can read the script to find out what
+those are.
 
-Then use `complement-conduit:dev` as a base image for running complement tests.

--- a/debian/README.md
+++ b/debian/README.md
@@ -1,4 +1,4 @@
-Conduit for Debian
+conduwuit for Debian
 ==================
 
 Installation

--- a/debian/postinst
+++ b/debian/postinst
@@ -35,50 +35,249 @@ case "$1" in
       CONDUIT_PORT="$RET"
       mkdir -p "$CONDUIT_CONFIG_PATH"
       cat > "$CONDUIT_CONFIG_FILE" << EOF
+# =============================================================================
+#  This is the official example config for conduwuit.
+#  If you use it for your server, you will need to adjust it to your own needs.
+#  At the very least, change the server_name field!
+# =============================================================================
+
 [global]
-# The server_name is the pretty name of this server. It is used as a suffix for
-# user and room ids. Examples: matrix.org, conduit.rs
+
+# The server_name is the pretty name of this server. It is used as a suffix for user
+# and room ids. Examples: matrix.org, conduit.rs
 
 # The Conduit server needs all /_matrix/ requests to be reachable at
 # https://your.server.name/ on port 443 (client-server) and 8448 (federation).
 
 # If that's not possible for you, you can create /.well-known files to redirect
-# requests. See
-# https://matrix.org/docs/spec/client_server/latest#get-well-known-matrix-client
+# requests (delegation). See
+# https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixclient
 # and
-# https://matrix.org/docs/spec/server_server/r0.1.4#get-well-known-matrix-server
+# https://spec.matrix.org/v1.9/server-server-api/#getwell-knownmatrixserver
 # for more information
 
+# YOU NEED TO EDIT THIS
 server_name = "${CONDUIT_SERVER_NAME}"
 
-# This is the only directory where Conduit will save its data.
+# Servers listed here will be used to gather public keys of other servers.
+# Generally, copying this exactly should be enough. (Currently, conduwuit doesn't
+# support batched key requests, so this list should only contain Synapse
+# servers.) Defaults to `matrix.org`
+# trusted_servers = ["matrix.org"]
+
+
+
+### Database configuration
+
+# This is the only directory where conduwuit will save its data, including media
 database_path = "${CONDUIT_DATABASE_PATH}"
+
+# Database backend: Only rocksdb and sqlite are supported. Please note that sqlite
+# will perform significantly worse than rocksdb as it is not intended to be used the
+# way it is by conduwuit. sqlite only exists for historical reasons.
 database_backend = "rocksdb"
 
-# The address Conduit will be listening on.
-# By default the server listens on address 0.0.0.0. Change this to 127.0.0.1 to
-# only listen on the localhost when using a reverse proxy.
-address = "${CONDUIT_ADDRESS}"
 
-# The port Conduit will be running on. You need to set up a reverse proxy in
-# your web server (e.g. apache or nginx), so all requests to /_matrix on port
-# 443 and 8448 will be forwarded to the Conduit instance running on this port
+
+### Network
+
+# The port conduwuit will be running on. You need to set up a reverse proxy such as
+# Caddy or Nginx so all requests to /_matrix on port 443 and 8448 will be
+# forwarded to the conduwuit instance running on this port
 # Docker users: Don't change this, you'll need to map an external port to this.
 port = ${CONDUIT_PORT}
 
-# Max size for uploads
+# default address (IPv4 or IPv6) conduwuit will listen on. Generally you want this to be
+# localhost (127.0.0.1 / ::1). If you are using Docker or a container NAT networking setup, you
+# likely need this to be 0.0.0.0. 
+address = "${CONDUIT_ADDRESS}"
+
+# How many requests conduwuit sends to other servers at the same time. Default is 100
+# Note that because conduwuit is very fast unlike other homeserver implementations,
+# setting this too high could inadvertently result in ratelimits kicking in, or
+# overloading lower-end homeservers out there. Recommended to leave this alone unless you
+# have a valid reason to. No this will not speed up room joins.
+#max_concurrent_requests = 100
+
+# Max request size for file uploads
 max_request_size = 20_000_000 # in bytes
 
-# Enables registration. If set to false, no users can register on this server.
-allow_registration = true
+# Uncomment unix_socket_path to listen on a UNIX socket at the specified path.
+# If listening on a UNIX socket, you must remove/comment the 'address' key if defined and add your
+# reverse proxy to the 'conduwuit' group, unless world RW permissions are specified with unix_socket_perms (666 minimum).
+#unix_socket_path = "/run/conduwuit/conduwuit.sock"
+#unix_socket_perms = 660
 
-allow_federation = true
+# Set this to true for conduwuit to compress HTTP response bodies using zstd.
+# Please be aware that enabling HTTP compression may weaken or even defeat TLS.
+# Most users should not need to enable this.
+# See https://breachattack.com/ and https://wikipedia.org/wiki/BREACH before deciding to enable this.
+zstd_compression = false
+
+# Vector list of IPv4 and IPv6 CIDR ranges / subnets *in quotes* that you do not want conduwuit to send outbound requests to.
+# Defaults to RFC1918, unroutable, loopback, multicast, and testnet addresses for security.
+#
+# To disable, set this to be an empty vector (`[]`).
+#
+# Currently this does not account for proxies in use like Synapse does.
+ip_range_denylist = [
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "100.64.0.0/10",
+    "192.0.0.0/24",
+    "169.254.0.0/16",
+    "192.88.99.0/24",
+    "198.18.0.0/15",
+    "192.0.2.0/24",
+    "198.51.100.0/24",
+    "203.0.113.0/24",
+    "224.0.0.0/4",
+    "::1/128",
+    "fe80::/10",
+    "fc00::/7",
+    "2001:db8::/32",
+    "ff00::/8",
+    "fec0::/10",
+]
+
+### Moderation / Privacy / Security
+
+# Set to true to allow user type "guest" registrations. Element attempts to register guest users automatically.
+# For private homeservers, this is best at false.
+allow_guest_registration = false
+
+# Vector list of servers that conduwuit will refuse to download remote media from.
+# No default.
+# prevent_media_downloads_from = ["example.com", "example.local"]
+
+# Enables open registration. If set to false, no users can register on this
+# server.
+# If set to true without a token configured, users can register with no form of 2nd-
+# step only if you set
+# `yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse` to
+# true in your config. If you would like
+# registration only via token reg, please configure the `registration_token` key.
+allow_registration = false
+# Please note that an open registration homeserver with no second-step verification
+# is highly prone to abuse and potential defederation by homeservers, including
+# matrix.org.
+
+# A static registration token that new users will have to provide when creating
+# an account. If unset and `allow_registration` is true, registration is open
+# without any condition. YOU NEED TO EDIT THIS.
+registration_token = "change this token for something specific to your server"
+
+# controls whether federation is allowed or not
+# defaults to true
+# allow_federation = true
+
+# controls whether users are allowed to create rooms.
+# appservices and admins are always allowed to create rooms
+# defaults to true
+# allow_room_creation = true
+
+# Set this to true to allow your server's public room directory to be federated.
+# Set this to false to protect against /publicRooms spiders, but will forbid external users
+# from viewing your server's public room directory. If federation is disabled entirely
+# (`allow_federation`), this is inherently false.
+allow_public_room_directory_over_federation = false
+
+# Set this to true to allow your server's public room directory to be queried without client
+# authentication (access token) through the Client APIs. Set this to false to protect against /publicRooms spiders.
+allow_public_room_directory_without_auth = false
+
+# Set this to true to allow federating device display names / allow external users to see your device display name.
+# If federation is disabled entirely (`allow_federation`), this is inherently false. For privacy, this is best disabled.
+allow_device_name_federation = false
+
+
+
+### Misc
+
+# max log level for conduwuit. allows debug, info, warn, or error
+#log = "warn"
+
+# controls whether encrypted rooms and events are allowed (default true)
+#allow_encryption = false
+
+# conduwuit will send a simple GET request periodically to `https://pupbrain.dev/check-for-updates/stable`
+# for any new announcements made. Despite the name, this is not an update check
+# endpoint, it is simply an announcement check endpoint. I don't plan on using
+# this so feel free to disable it.
 allow_check_for_updates = true
 
-trusted_servers = ["matrix.org"]
+# Enables adding the lightning bolt emoji (⚡️) to all newly registered users'
+# initial display names. 
+enable_lightning_bolt = false
 
-#max_concurrent_requests = 400 # How many requests Conduit sends to other servers at the same time
-#log = "warn,state_res=warn"
+# If you are using delegation via well-known files and you cannot serve them from your reverse proxy, you can
+# uncomment these to serve them directly from conduwuit. This requires proxying all requests to conduwuit, not just `/_matrix` to work.
+#well_known_server = "matrix.example.com:443"
+#well_known_client = "https://matrix.example.com"
+# Note that whatever you put will show up in the well-known JSON values.
+
+# Set to false to disable users from joining or creating room versions that aren't 100% officially supported by conduwuit.
+# conduwuit officially supports room versions 6 - 10. conduwuit has experimental/unstable support for 1 - 5, and 11.
+# Defaults to true.
+#allow_unstable_room_versions = true
+
+# Set this to any float value to multiply conduwuit's in-memory LRU caches with.
+# May be useful if you have significant memory to spare to increase performance.
+# Defaults to 1.0.
+#conduit_cache_capacity_modifier = 1.0
+
+# Set this to any float value in megabytes for conduwuit to tell the database engine that this much memory is available for database-related caches.
+# May be useful if you have significant memory to spare to increase performance.
+# Defaults to 900.0
+#db_cache_capacity_mb = 900.0
+
+
+
+### RocksDB options
+
+# Set this to true to use RocksDB config options that are tailored to HDDs (slower device storage)
+#rocksdb_optimize_for_spinning_disks = false
+
+# RocksDB log level. This is not the same as conduwuit's log level. This is the log level for RocksDB itself
+# which show up in your database folder/path as `LOG` files. Defaults to warn. conduwuit will typically log RocksDB errors. 
+#rocksdb_log_level = "warn"
+
+# Max RocksDB `LOG` file size before rotating in bytes. Defaults to 4MB.
+#rocksdb_max_log_file_size = 4194304
+
+# Time in seconds before RocksDB will forcibly rotate logs. Defaults to 0.
+#rocksdb_log_time_to_roll = 0
+
+
+
+### Presence
+
+# Config option to control local (your server only) presence updates/requests. Defaults to false.
+# Note that presence on conduwuit is very fast unlike Synapse's.
+#allow_local_presence = false
+
+# Config option to control incoming federated presence updates/requests. Defaults to false.
+# This option receives presence updates from other servers, but does not send any unless `allow_outgoing_presence` is true.
+# Note that presence on conduwuit is very fast unlike Synapse's.
+#allow_incoming_presence = false
+
+# Config option to control outgoing presence updates/requests. Defaults to false.
+# This option sends presence updates to other servers, but does not receive any unless `allow_incoming_presence` is true.
+# Note that presence on conduwuit is very fast unlike Synapse's.
+#
+# Warning: Outgoing federated presence is not spec compliant due to relying on PDUs and EDUs combined.
+# Outgoing presence will not be very reliable due to this and any issues with federated outgoing presence are very likely attributed to this issue.
+# Incoming presence and local presence are unaffected.
+#allow_outgoing_presence = false
+
+# Config option to control how many seconds before presence updates that you are idle. Defaults to 5 minutes.
+#presence_idle_timeout_s = 300
+
+# Config option to control how many seconds before presence updates that you are offline. Defaults to 30 minutes.
+#presence_offline_timeout_s = 1800
+
 EOF
     fi
     ;;

--- a/flake.lock
+++ b/flake.lock
@@ -51,16 +51,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1706070683,
-        "narHash": "sha256-iQoXIFviH5QbSKDkWyFJKKUtTcSiCvl1tW18ax+pKfI=",
-        "owner": "CobaltCause",
+        "lastModified": 1706473964,
+        "narHash": "sha256-Fq6xleee/TsX6NbtoRuI96bBuDHMU57PrcK9z1QEKbk=",
+        "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8060686afabc5b042e8982200cb2cc3fd22cf416",
+        "rev": "c798790eabec3e3da48190ae3698ac227aab770c",
         "type": "github"
       },
       "original": {
-        "owner": "CobaltCause",
-        "ref": "crimes-for-cross",
+        "owner": "ipetkov",
+        "ref": "master",
         "repo": "crane",
         "type": "github"
       }
@@ -73,11 +73,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1706336364,
-        "narHash": "sha256-mJ5i2YIVKv6jTN2+l3oOUUej2NUVjJX/H3bAq6019ks=",
+        "lastModified": 1706422804,
+        "narHash": "sha256-+ypK8QbE9RBe0sK4lAM4+8H4K85BB3BsDKMD7WbykBU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "eb683549b7d76b12d1a009f888b91b70ed34485f",
+        "rev": "ce6fec88804dfd11e610cfd04333c23abeae80a8",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1706295183,
-        "narHash": "sha256-VSyMaUsXfjb31B8/uT5cM5qXC1VOHLVsCi/bQuo3O/g=",
+        "lastModified": 1706352756,
+        "narHash": "sha256-6K5rK1b2APQfXOrC+Hm+0QcyfPVt+TV81Q6Fd/QjMlQ=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "596e5c77cf5b2b660b3ac2ce732fa0596c246d9b",
+        "rev": "7219414e81810fd4d967136c4a0650523892c157",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane = {
-      # TODO: Switch back to upstream after [this issue][0] is fixed
-      #
-      # [0]: https://github.com/ipetkov/crane/issues/497
-      url = "github:CobaltCause/crane?ref=crimes-for-cross";
+      url = "github:ipetkov/crane?ref=master";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     attic.url = "github:zhaofengli/attic?ref=main";

--- a/flake.nix
+++ b/flake.nix
@@ -244,6 +244,13 @@
           toolchain
         ] ++ (with pkgsHost; [
           engage
+
+          # Needed for Complement
+          go
+          olm
+
+          # Needed for our script for Complement
+          jq
         ]);
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -26,16 +26,6 @@
     , ...
     }: flake-utils.lib.eachDefaultSystem (system:
     let
-      rocksdb' = pkgs: pkgs.rocksdb.overrideAttrs (old:
-              {
-                src = pkgs.fetchFromGitHub {
-                  owner = "facebook";
-                  repo = "rocksdb";
-                  rev = "v8.10.0";
-                  hash = "sha256-KGsYDBc1fz/90YYNGwlZ0LUKXYsP1zyhP29TnRQwgjQ=";
-                };
-              });
-
       pkgsHost = nixpkgs.legacyPackages.${system};
 
       # Nix-accessible `Cargo.toml`
@@ -60,8 +50,8 @@
       ];
 
       env = pkgs: {
-        ROCKSDB_INCLUDE_DIR = "${rocksdb' pkgs}/include";
-        ROCKSDB_LIB_DIR = "${rocksdb' pkgs}/lib";
+        ROCKSDB_INCLUDE_DIR = "${pkgs.rocksdb}/include";
+        ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
       }
       // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isStatic {
         ROCKSDB_STATIC = "";

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -853,7 +853,9 @@ impl KeyValueDatabase {
                         if rule.is_some() {
                             let mut rule = rule.unwrap().clone();
                             rule.rule_id = content_rule_transformation[1].to_owned();
-                            rules_list.content.remove(content_rule_transformation[0]);
+                            rules_list
+                                .content
+                                .shift_remove(content_rule_transformation[0]);
                             rules_list.content.insert(rule);
                         }
                     }
@@ -876,7 +878,7 @@ impl KeyValueDatabase {
                             if let Some(rule) = rule {
                                 let mut rule = rule.clone();
                                 rule.rule_id = transformation[1].to_owned();
-                                rules_list.underride.remove(transformation[0]);
+                                rules_list.underride.shift_remove(transformation[0]);
                                 rules_list.underride.insert(rule);
                             }
                         }


### PR DESCRIPTION
- Builds static x86 and aarch64 Linux musl binaries
- Builds x86 and aarch64 OCI images for Docker
- Builds x86 deb file (no aarch64 until upstream has it)

Also merges the rest of some upstream changes related to GitLab CI so we could copy.