### PR TITLE
Reduce number of separate sources of truth for presence disabled-ness

### DIFF
--- a/src/api/client_server/profile.rs
+++ b/src/api/client_server/profile.rs
@@ -85,12 +85,10 @@ pub async fn set_displayname_route(
 			.await;
 	}
 
-	if services().globals.allow_local_presence() {
-		// Presence update
-		services()
-			.presence
-			.ping_presence(sender_user, PresenceState::Online)?;
-	}
+	// Presence update
+	services()
+		.presence
+		.ping_presence(sender_user, PresenceState::Online)?;
 
 	Ok(set_display_name::v3::Response {})
 }
@@ -224,12 +222,10 @@ pub async fn set_avatar_url_route(body: Ruma<set_avatar_url::v3::Request>) -> Re
 			.await;
 	}
 
-	if services().globals.allow_local_presence() {
-		// Presence update
-		services()
-			.presence
-			.ping_presence(sender_user, PresenceState::Online)?;
-	}
+	// Presence update
+	services()
+		.presence
+		.ping_presence(sender_user, PresenceState::Online)?;
 
 	Ok(set_avatar_url::v3::Response {})
 }

--- a/src/api/client_server/sync.rs
+++ b/src/api/client_server/sync.rs
@@ -171,11 +171,9 @@ async fn sync_helper(
 	// bool = caching allowed
 ) -> Result<(sync_events::v3::Response, bool), Error> {
 	// Presence update
-	if services().globals.allow_local_presence() {
-		services()
-			.presence
-			.ping_presence(&sender_user, body.set_presence)?;
-	}
+	services()
+		.presence
+		.ping_presence(&sender_user, body.set_presence)?;
 
 	// Setup watchers, so if there's no response, we can wait for them
 	let watcher = services().globals.watch(&sender_user, &sender_device);


### PR DESCRIPTION
Instead of checking if we should update every time we want to update, call the updater every time and decide internally.