### PR TITLE
remove created date from OCI image generation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -197,8 +197,6 @@
         pkgs.dockerTools.buildImage {
           name = package.pname;
           tag = "main";
-          # Debian makes builds reproducible through using the HEAD commit's date
-          created = builtins.substring 0 8 self.lastModifiedDate;
           copyToRoot = [
             pkgs.dockerTools.caCertificates
           ];


### PR DESCRIPTION
dockerhub and github container registry don't like this, and i have no idea what to do.