### PR TITLE
Set the time of the HEAD commit as the OCI created field

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -194,10 +194,12 @@
       };
 
       mkOciImage = pkgs: package: allocator:
-        pkgs.dockerTools.buildImage {
+        pkgs.dockerTools.buildLayeredImage {
           name = package.pname;
           tag = "main";
-          copyToRoot = [
+          # Debian makes builds reproducible through using the HEAD commit's date
+          created = "@${toString self.lastModified}";
+          contents = [
             pkgs.dockerTools.caCertificates
           ];
           config = {


### PR DESCRIPTION
Apparently it uses `date -Iseconds -d <input>` to parse, so we can use @ with a timestamp for a little more accuracy

Also it doesn't parse `created` in buildImage, only buildLayeredImage :thinking: 

Signed-off-by: morguldir <morguldir@protonmail.com>
