### PR TITLE
unpin/update crane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,17 +51,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1707685877,
-        "narHash": "sha256-XoXRS+5whotelr1rHiZle5t5hDg9kpguS5yk8c8qzOc=",
+        "lastModified": 1713721181,
+        "narHash": "sha256-Vz1KRVTzU3ClBfyhOj8gOehZk21q58T1YsXC30V23PU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c653e4478476a52c6aa3ac0495e4dea7449ea0e",
+        "rev": "55f4939ac59ff8f89c6a4029730a2d49ea09105f",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
+        "ref": "master",
         "repo": "crane",
-        "rev": "2c653e4478476a52c6aa3ac0495e4dea7449ea0e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,12 +13,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane = {
-      # Pin latest crane that's not affected by the following bugs:
-      #
-      # * <https://github.com/ipetkov/crane/issues/527#issuecomment-1978079140>
-      # * <https://github.com/toml-rs/toml/issues/691>
-      # * <https://github.com/toml-rs/toml/issues/267>
-      url = "github:ipetkov/crane?rev=2c653e4478476a52c6aa3ac0495e4dea7449ea0e";
+      url = "github:ipetkov/crane?ref=master";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     attic.url = "github:zhaofengli/attic?ref=main";


### PR DESCRIPTION
I only tested `nom build` on the default package and it built fine, I would be surprised if that didn't carry over to the other outputs.