### PR TITLE
CI working with job summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
     tests:
-        name: Prepare and test
+        name: Test
         runs-on: ubuntu-latest
         steps:
             - name: Sync repository
@@ -59,19 +59,27 @@ jobs:
                   extra-trusted-public-keys = ${{ env.ATTIC_PUBLIC_KEY }}
                   EOF
 
-            - name: Install and activate `direnv`
+            - name: Prepare build environment
               run: |
                   echo 'source $HOME/.nix-profile/share/nix-direnv/direnvrc' > "$HOME/.direnvrc"
                   nix-env -f "<nixpkgs>" -iA direnv -iA nix-direnv
                   direnv allow
-
-            - name: Update `/nix/store`
-              run: |
                   nix develop --command true
 
             - name: Run CI tests
               run: |
-                  direnv exec . engage
+                  direnv exec . engage > >(tee -a test_output.log)
+
+            - name: Update Job Summary
+              if: success() || failure()
+              run: |
+                  if [ ${{ job.status }} == 'success' ]; then
+                      echo '# ✅' >> $GITHUB_STEP_SUMMARY
+                  else
+                      echo '```' >> $GITHUB_STEP_SUMMARY
+                      tail -n 20 test_output.log | sed 's/\x1b\[[0-9;]*m//g' >> $GITHUB_STEP_SUMMARY
+                      echo '```' >> $GITHUB_STEP_SUMMARY
+                  fi
 
     build:
         name: Build
@@ -116,14 +124,11 @@ jobs:
                   extra-trusted-public-keys = ${{ env.ATTIC_PUBLIC_KEY }}
                   EOF
 
-            - name: Install and activate `direnv`
+            - name: Prepare build environment
               run: |
                   echo 'source $HOME/.nix-profile/share/nix-direnv/direnvrc' > "$HOME/.direnvrc"
                   nix-env -f "<nixpkgs>" -iA direnv -iA nix-direnv
                   direnv allow
-
-            - name: Update `/nix/store`
-              run: |
                   nix develop --command true
 
             - name: Build static ${{ matrix.target }}
@@ -162,10 +167,19 @@ jobs:
                   compression-level: 0
 
     docker:
-        name: Publish Docker manifests
+        name: Docker publish
         runs-on: ubuntu-latest
         needs: build
         if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name != 'pull_request'
+        env:
+            DOCKER_ARM64: docker.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-arm64v8
+            DOCKER_AMD64: docker.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-amd64
+            DOCKER_TAG: docker.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
+            DOCKER_BRANCH: docker.io/${{ github.repository }}:${{ (github.ref == 'refs/heads/main' && 'latest') || github.ref_name }}
+            GHCR_ARM64: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-arm64v8
+            GHCR_AMD64: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-amd64
+            GHCR_TAG: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
+            GHCR_BRANCH: ghcr.io/${{ github.repository }}:${{ (github.ref == 'refs/heads/main' && 'latest') || github.ref_name }}
         steps:
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
@@ -184,38 +198,42 @@ jobs:
             - name: Download artifacts
               uses: actions/download-artifact@v4
 
-            - name: Create and push manifests to GitHub and Docker Hub
-              env:
-                  BRANCH_TAG: ${{ github.ref_name }}
+            - name: Move OCI images into position
               run: |
-                  mv oci-image-*/oci-image-*.tar.gz .
-                  docker load -i oci-image-aarch64-unknown-linux-musl-jemalloc.tar.gz
-                  docker tag $(docker images -q conduit:main) conduwuit:${{ github.sha }}-aarch64-jemalloc
-                  docker load -i oci-image-x86_64-unknown-linux-musl-jemalloc.tar.gz
-                  docker tag $(docker images -q conduit:main) conduwuit:${{ github.sha }}-x86_64-jemalloc
+                  mv oci-image-x86_64-*-jemalloc/*.tar.gz oci-image-amd64.tar.gz
+                  mv oci-image-aarch64-*-jemalloc/*.tar.gz oci-image-arm64v8.tar.gz
 
-                  if [ "$BRANCH_TAG" == "main" ]; then
-                      BRANCH_TAG="latest"
-                  fi
+            - name: Load and push amd64 image
+              run: |
+                  docker load -i oci-image-amd64.tar.gz
+                  docker tag $(docker images -q conduit:main) ${{ env.DOCKER_AMD64 }}
+                  docker tag $(docker images -q conduit:main) ${{ env.GHCR_AMD64 }}
+                  docker push ${{ env.DOCKER_AMD64 }}
+                  docker push ${{ env.GHCR_AMD64 }}
 
-                  # Creating and pushing for GitHub Container Registry
-                  docker manifest create ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }} \
-                      --amend conduwuit:${{ github.sha }}-x86_64-jemalloc \
-                      --amend conduwuit:${{ github.sha }}-aarch64-jemalloc
-                  docker manifest push ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
+            - name: Load and push arm64 image
+              run: |
+                  docker load -i oci-image-arm64v8.tar.gz
+                  docker tag $(docker images -q conduit:main) ${{ env.DOCKER_ARM64 }}
+                  docker tag $(docker images -q conduit:main) ${{ env.GHCR_ARM64 }}
+                  docker push ${{ env.DOCKER_ARM64 }}
+                  docker push ${{ env.GHCR_ARM64 }}
 
-                  docker manifest create ghcr.io/${{ github.repository }}:$BRANCH_TAG \
-                      --amend conduwuit:${{ github.sha }}-x86_64-jemalloc \
-                      --amend conduwuit:${{ github.sha }}-aarch64-jemalloc
-                  docker manifest push ghcr.io/${{ github.repository }}:$BRANCH_TAG
+            - name: Create Docker combined manifests
+              run: |
+                  docker manifest create ${{ env.DOCKER_TAG }} --amend ${{ env.DOCKER_ARM64 }} --amend ${{ env.DOCKER_AMD64 }}
+                  docker manifest create ${{ env.DOCKER_BRANCH }} --amend ${{ env.DOCKER_ARM64 }} --amend ${{ env.DOCKER_AMD64 }}
+                  docker manifest create ${{ env.GHCR_TAG }} --amend ${{ env.GHCR_ARM64 }} --amend ${{ env.GHCR_AMD64 }}
+                  docker manifest create ${{ env.GHCR_BRANCH }} --amend ${{ env.GHCR_ARM64 }} --amend ${{ env.GHCR_AMD64 }}
 
-                  # Creating and pushing for Docker Hub
-                  docker manifest create docker.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }} \
-                      --amend conduwuit:${{ github.sha }}-x86_64-jemalloc \
-                      --amend conduwuit:${{ github.sha }}-aarch64-jemalloc
-                  docker manifest push docker.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
+            - name: Push manifests to Docker registries
+              run: |
+                  docker manifest push ${{ env.DOCKER_TAG }}
+                  docker manifest push ${{ env.DOCKER_BRANCH }}
+                  docker manifest push ${{ env.GHCR_TAG }}
+                  docker manifest push ${{ env.GHCR_BRANCH }}
 
-                  docker manifest create docker.io/${{ github.repository }}:$BRANCH_TAG \
-                      --amend conduwuit:${{ github.sha }}-x86_64-jemalloc \
-                      --amend conduwuit:${{ github.sha }}-aarch64-jemalloc
-                  docker manifest push docker.io/${{ github.repository }}:$BRANCH_TAG
+            - name: Add Image Links to Job Summary
+              run: |
+                  echo "- \`docker pull ${{ env.DOCKER_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- \`docker pull ${{ env.GHCR_TAG }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
All images should be generating correctly with parallelism and Docker manifests, and should output the end of the CI testing errors in a job summary box when the test fails.

When the test succeeds you get a big ✅ then at the end of the Docker publish it should include the `docker pull` commands for both Docker Hub and GHCR registries to make those pesky Docker users lives easier!