### PR TITLE
Downgrade zeroize to a non-yanked version in lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zstd"


### PR DESCRIPTION
[Version 1.8.0](https://crates.io/crates/zeroize/1.8.0) was yanked, although I couldn't find anything explaining why in the zeroize repo. This is causing CI failures. If I learn why it was yanked I'll put a comment on this PR.