### PR TITLE
Fix tracing-flame bugs and add some config options

### DIFF
--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -336,6 +336,18 @@ allow_profile_lookup_federation_requests = true
 # messages without any attempt at redelivery.
 #startup_netburst_keep = 50
 
+# If the 'perf_measurements' feature is enabled, enables collecting folded stack trace profile of tracing spans using
+# tracing_flame. The resulting profile can be visualized with inferno[1], speedscope[2], or a number of other tools.
+# [1]: https://github.com/jonhoo/inferno
+# [2]: www.speedscope.app
+# tracing_flame = false
+
+# If 'tracing_flame' is enabled, sets a filter for which events will be included in the profile.
+# Supported syntax is documented at https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+# tracing_flame_filter = "trace,h2=off"
+
+# If 'tracing_flame' is enabled, set the path to write the generated profile.
+# tracing_flame_output_path = "./tracing.folded"
 
 ### Generic database options
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -175,6 +175,9 @@ pub(crate) struct Config {
 	#[serde(default)]
 	#[cfg(feature = "perf_measurements")]
 	pub(crate) tracing_flame: bool,
+	#[serde(default = "default_tracing_flame_filter")]
+	#[cfg(feature = "perf_measurements")]
+	pub(crate) tracing_flame_filter: String,
 	#[serde(default)]
 	pub(crate) proxy: ProxyConfig,
 	pub(crate) jwt_secret: Option<String>,
@@ -933,6 +936,9 @@ fn default_appservice_idle_timeout() -> u64 { 300 }
 fn default_pusher_idle_timeout() -> u64 { 15 }
 
 fn default_max_fetch_prev_events() -> u16 { 100_u16 }
+
+#[cfg(feature = "perf_measurements")]
+fn default_tracing_flame_filter() -> String { "trace,h2=off".to_owned() }
 
 fn default_trusted_servers() -> Vec<OwnedServerName> { vec![OwnedServerName::try_from("matrix.org").unwrap()] }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -178,6 +178,9 @@ pub(crate) struct Config {
 	#[serde(default = "default_tracing_flame_filter")]
 	#[cfg(feature = "perf_measurements")]
 	pub(crate) tracing_flame_filter: String,
+	#[serde(default = "default_tracing_flame_output_path")]
+	#[cfg(feature = "perf_measurements")]
+	pub(crate) tracing_flame_output_path: String,
 	#[serde(default)]
 	pub(crate) proxy: ProxyConfig,
 	pub(crate) jwt_secret: Option<String>,
@@ -939,6 +942,9 @@ fn default_max_fetch_prev_events() -> u16 { 100_u16 }
 
 #[cfg(feature = "perf_measurements")]
 fn default_tracing_flame_filter() -> String { "trace,h2=off".to_owned() }
+
+#[cfg(feature = "perf_measurements")]
+fn default_tracing_flame_output_path() -> String { "./tracing.folded".to_owned() }
 
 fn default_trusted_servers() -> Vec<OwnedServerName> { vec![OwnedServerName::try_from("matrix.org").unwrap()] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -617,7 +617,10 @@ fn init_tracing(config: &Config) -> LogLevelReloadHandles {
 	#[cfg(feature = "perf_measurements")]
 	let subscriber = {
 		let flame_layer = if config.tracing_flame {
-			let flame_filter = EnvFilter::new("trace,h2=off");
+			let flame_filter = match EnvFilter::try_new(&config.tracing_flame_filter) {
+				Ok(flame_filter) => flame_filter,
+				Err(e) => panic!("tracing_flame_filter config value is invalid: {e}"),
+			};
 
 			// TODO: actually preserve this guard until exit: https://docs.rs/tracing-flame/latest/tracing_flame/struct.FlameLayer.html#dropping-and-flushing
 			let (flame_layer, _guard) = tracing_flame::FlameLayer::with_file("./tracing.folded").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,13 @@ fn init_tracing(config: &Config) -> (LogLevelReloadHandles, TracingFlameGuard) {
 				Err(e) => panic!("tracing_flame_filter config value is invalid: {e}"),
 			};
 
-			let (flame_layer, flame_guard) = tracing_flame::FlameLayer::with_file("./tracing.folded").unwrap();
+			let (flame_layer, flame_guard) =
+				match tracing_flame::FlameLayer::with_file(&config.tracing_flame_output_path) {
+					Ok(ok) => ok,
+					Err(e) => {
+						panic!("failed to initialize tracing-flame: {e}");
+					},
+				};
 			let flame_layer = flame_layer
 				.with_empty_samples(false)
 				.with_filter(flame_filter);


### PR DESCRIPTION
Bugs fixed:

 - enabling tracing-flame would disable normal logging
 - tracing-flame IO buffers were not flushed on exit
 - when tracing-flame was enabled, changing the log level at runtime with the admin interface would modify the tracing-flame filter instead of the log level (which didn't exist because it wasn't logging anything on stdout)

I also added a couple options to make tracing_flame that were necessary to use tracing-flame on our HS.

The refactoring that fixed the first bug (stdout logging being disabled) also fixed a similar bug for jaeger. Even after this fix, jaeger is still not working because we're initializing it outside of the tokio context. If you try to run conduwuit with `allow_jaeger = true`, it will panic. We discussed removing jaeger support instead of fixing it in the matrix room, but I'm going to save that for a later PR. I might try making a janky patch to get jaeger working and see if it's useful for debugging problems on our HS first.