### PR TITLE
fix extra version when using flake-compat

### DIFF
--- a/nix/pkgs/main/default.nix
+++ b/nix/pkgs/main/default.nix
@@ -37,7 +37,7 @@ buildDepsOnlyEnv =
   });
 
 buildPackageEnv = {
-  CONDUWUIT_VERSION_EXTRA = inputs.self.shortRev or inputs.self.dirtyShortRev;
+  CONDUWUIT_VERSION_EXTRA = inputs.self.shortRev or inputs.self.dirtyShortRev or "";
 } // buildDepsOnlyEnv;
 
 commonAttrs = {


### PR DESCRIPTION
Currently, trying to use conduwuit with Nix without flakes (using the `default.nix` which uses flake-compat) fails because the `CONDUWUIT_EXTRA_VERSION` env var is set using values from `inputs.self`. flake-compat doesn't provide `self` in inputs, just the actual inputs, so this change falls back to an empty string if `inputs.self` isn't available.