### PR TITLE
Draft: partial filtering support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
             GHCR_AMD64: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-amd64
             GHCR_TAG: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
             GHCR_BRANCH: ghcr.io/${{ github.repository }}:${{ (github.ref == 'refs/heads/main' && 'latest') || github.ref_name }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         steps:
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
@@ -205,6 +206,7 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Login to Docker Hub
+              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               uses: docker/login-action@v3
               with:
                   registry: docker.io
@@ -220,6 +222,7 @@ jobs:
                   mv oci-image-aarch64-*-jemalloc/*.tar.gz oci-image-arm64v8.tar.gz
 
             - name: Load and push amd64 image
+              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker load -i oci-image-amd64.tar.gz
                   docker tag $(docker images -q conduit:main) ${{ env.DOCKER_AMD64 }}
@@ -228,6 +231,7 @@ jobs:
                   docker push ${{ env.GHCR_AMD64 }}
 
             - name: Load and push arm64 image
+              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker load -i oci-image-arm64v8.tar.gz
                   docker tag $(docker images -q conduit:main) ${{ env.DOCKER_ARM64 }}
@@ -243,6 +247,7 @@ jobs:
                   docker manifest create ${{ env.GHCR_BRANCH }} --amend ${{ env.GHCR_ARM64 }} --amend ${{ env.GHCR_AMD64 }}
 
             - name: Push manifests to Docker registries
+              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker manifest push ${{ env.DOCKER_TAG }}
                   docker manifest push ${{ env.DOCKER_BRANCH }}
@@ -250,6 +255,7 @@ jobs:
                   docker manifest push ${{ env.GHCR_BRANCH }}
 
             - name: Add Image Links to Job Summary
+              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   echo "- \`docker pull ${{ env.DOCKER_TAG }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "- \`docker pull ${{ env.GHCR_TAG }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,9 +129,9 @@ artifacts:
 
 .push-oci-image:
   stage: publish
-  image: docker:26.0.2
+  image: docker:26.1.0
   services:
-    - docker:26.0.2-dind
+    - docker:26.1.0-dind
   variables:
     IMAGE_SUFFIX_AMD64: amd64
     IMAGE_SUFFIX_ARM64V8: arm64v8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
+name = "anyhow"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,18 +145,46 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.3",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -171,6 +205,23 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
@@ -178,8 +229,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -195,13 +246,13 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
 dependencies = [
- "axum",
- "axum-core",
+ "axum 0.7.5",
+ "axum-core 0.4.3",
  "bytes",
  "futures-util",
  "headers",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -220,10 +271,10 @@ dependencies = [
  "arc-swap",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.11",
@@ -242,7 +293,7 @@ checksum = "7ea4cd08ae2a5f075d28fa31190163c8106a1d2d3189442494bae22b39040a0d"
 dependencies = [
  "axum-server",
  "bytes",
- "http",
+ "http 1.1.0",
  "http-body-util",
  "pin-project",
  "tokio",
@@ -505,7 +556,7 @@ version = "0.3.0"
 dependencies = [
  "argon2",
  "async-trait",
- "axum",
+ "axum 0.7.5",
  "axum-extra",
  "axum-server",
  "axum-server-dual-protocol",
@@ -513,6 +564,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "console-subscriber",
  "cyborgtime",
  "either",
  "figment",
@@ -521,9 +573,9 @@ dependencies = [
  "hickory-resolver",
  "hmac",
  "hot-lib-reloader",
- "http",
+ "http 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "image",
  "ipaddress",
@@ -571,6 +623,42 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "webpage",
+]
+
+[[package]]
+name = "console-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -918,6 +1006,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1139,25 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
@@ -1046,8 +1167,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap",
+ "http 1.1.0",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -1059,6 +1180,12 @@ name = "hardened_malloc-rs"
 version = "0.1.2+12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "647deb1583b14d160f85f3ff626f20b6edd366e3852c9843b06077388f794cb6"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1076,7 +1203,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -1088,7 +1228,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1100,7 +1240,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1244,6 +1384,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1255,12 +1406,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1271,8 +1433,8 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1289,6 +1451,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,9 +1489,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -1316,14 +1508,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.1.0",
+ "hyper 1.3.1",
  "hyper-util",
  "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.28",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1335,9 +1539,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1395,12 +1599,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -1476,6 +1690,15 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2016,7 +2239,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap",
+ "indexmap 2.2.6",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2341,6 +2564,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,10 +2706,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hickory-resolver",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -2551,7 +2806,7 @@ dependencies = [
  "assign",
  "bytes",
  "date_header",
- "http",
+ "http 1.1.0",
  "js_int",
  "js_option",
  "maplit",
@@ -2573,8 +2828,8 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "form_urlencoded",
- "http",
- "indexmap",
+ "http 1.1.0",
+ "indexmap 2.2.6",
  "js_int",
  "konst",
  "percent-encoding",
@@ -2600,7 +2855,7 @@ version = "0.27.11"
 source = "git+https://github.com/girlbossceo/ruma?branch=conduwuit-changes#7136799881d0fcb18aad26c3dac18a34a1f892fc"
 dependencies = [
  "as_variant",
- "indexmap",
+ "indexmap 2.2.6",
  "js_int",
  "js_option",
  "percent-encoding",
@@ -3020,7 +3275,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df141464944fdf8e2a6f2184eb1d973a20456466f788346b6e3a51791cdaa370"
 dependencies = [
- "http",
+ "http 1.1.0",
  "pin-project",
  "sentry-core",
  "tower-layer",
@@ -3084,7 +3339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
 dependencies = [
  "form_urlencoded",
- "indexmap",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3148,7 +3403,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3516,7 +3771,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3615,11 +3881,39 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3630,9 +3924,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3649,8 +3947,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -3676,8 +3974,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tracing"
 version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3688,8 +3985,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3699,8 +3995,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3729,6 +4024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3741,7 +4046,7 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber",
  "web-time 0.2.4",
 ]
@@ -3749,8 +4054,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3761,7 +4065,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0 (git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3974,7 +3974,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tracing"
 version = "0.1.40"
-source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
+source = "git+https://github.com/girlbossceo/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.27"
-source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
+source = "git+https://github.com/girlbossceo/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.32"
-source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
+source = "git+https://github.com/girlbossceo/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.2.0"
-source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
+source = "git+https://github.com/girlbossceo/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "log",
  "once_cell",
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
-source = "git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
+source = "git+https://github.com/girlbossceo/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport#b348dca742af641c47bc390261f60711c2af573c"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4065,7 +4065,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0 (git+https://github.com/Benjamin-L/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport)",
+ "tracing-log 0.2.0 (git+https://github.com/girlbossceo/tracing?branch=tracing-subscriber/env-filter-clone-0.1.x-backport)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -311,7 +311,7 @@ checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -470,12 +470,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -503,7 +497,7 @@ checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.3",
+ "libloading",
 ]
 
 [[package]]
@@ -590,7 +584,6 @@ dependencies = [
  "opentelemetry-jaeger",
  "opentelemetry_sdk",
  "parking_lot",
- "proc-macro2",
  "rand",
  "regex",
  "reqwest",
@@ -704,7 +697,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -738,7 +731,7 @@ version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
@@ -912,12 +905,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "windows-sys 0.52.0",
@@ -932,7 +934,7 @@ dependencies = [
  "cc",
  "lazy_static",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -961,39 +963,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsevent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
-dependencies = [
- "bitflags 1.3.2",
- "fsevent-sys",
-]
-
-[[package]]
 name = "fsevent-sys"
-version = "2.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags 1.3.2",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futf"
@@ -1108,7 +1084,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -1274,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -1297,7 +1273,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "futures-util",
  "hickory-proto",
  "ipconfig",
@@ -1329,7 +1305,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1338,30 +1314,31 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "windows",
 ]
 
 [[package]]
 name = "hot-lib-reloader"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7767568f2f3adb7ce2926a261fd838f161f3549c1b7e64a4c67a8a4c574e8c"
+checksum = "eda706fdb8bcf5279ce95754dd86a23eab0a81ad2823d5402c2e10a4dd3283c2"
 dependencies = [
  "crc32fast",
  "hot-lib-reloader-macro",
- "libloading 0.7.4",
+ "libloading",
  "log",
  "notify",
+ "notify-debouncer-full",
  "thiserror",
 ]
 
 [[package]]
 name = "hot-lib-reloader-macro"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5551f8a39fa95a6b6d0cc0a8a7ccf8df4d62cc12731d5153eb64e1405e77762"
+checksum = "f01c6c25eabdd8e2de50ccdb7e13186ba2ac0f69ebd8bd5f96ae235414180800"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1626,9 +1603,9 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inotify"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
@@ -1649,15 +1626,6 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "ipaddress"
@@ -1776,16 +1744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "konst"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1761,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0a455a1719220fd6adf756088e1c69a85bf14b6a9e24537a5cc04f503edb2b"
 dependencies = [
  "typewit",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1825,21 +1803,11 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if 1.0.0",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-targets 0.52.5",
 ]
 
@@ -2000,67 +1968,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2076,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.5.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cfg_aliases",
  "libc",
 ]
@@ -2093,20 +2008,35 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "4.0.17"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
+ "crossbeam-channel",
  "filetime",
- "fsevent",
  "fsevent-sys",
  "inotify",
+ "kqueue",
  "libc",
- "mio 0.6.23",
- "mio-extras",
+ "log",
+ "mio",
  "walkdir",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]
@@ -2116,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2345,7 +2275,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2757,7 +2687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
@@ -3416,7 +3346,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3427,7 +3357,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3438,7 +3368,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3653,7 +3583,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3765,7 +3695,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.11",
+ "mio",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4245,7 +4175,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -4270,7 +4200,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4382,12 +4312,6 @@ checksum = "939e59c1bc731542357fdaad98b209ef78c8743d652bb61439d16b16a79eb025"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -4395,12 +4319,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4596,7 +4514,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -4606,18 +4524,8 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.75.0"
 [dependencies]
 console-subscriber = { version = "0.1", optional = true }
 
-hot-lib-reloader = { version = "^0.6", optional = true }
+hot-lib-reloader = { version = "^0.7", optional = true }
 
 # Used for secure identifiers
 rand = "0.8.5"
@@ -80,8 +80,6 @@ url = { version = "2", features = ["serde"] }
 async-trait = "0.1.80"
 
 lru-cache = "0.1.2"
-
-proc-macro2 = "=1.0.79"
 
 # standard date and time tools
 [dependencies.chrono]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rust-version = "1.75.0"
 
 
 [dependencies]
+console-subscriber = { version = "0.1", optional = true }
+
 hot-lib-reloader = { version = "^0.6", optional = true }
 
 # Used for secure identifiers
@@ -338,6 +340,18 @@ hardened_malloc-rs = { version = "0.1.2", optional = true, features = [
 #hardened_malloc-rs = { optional = true, features = ["static","clang","light"], path = "../hardened_malloc-rs", default-features = false }
 
 
+# backport of [https://github.com/tokio-rs/tracing/pull/2956] to the 0.1.x branch of tracing.
+# we can switch back to upstream if #2956 is merged and backported in the upstream repo.
+[patch.crates-io.tracing-subscriber]
+git = "https://github.com/Benjamin-L/tracing"
+branch = "tracing-subscriber/env-filter-clone-0.1.x-backport"
+[patch.crates-io.tracing]
+git = "https://github.com/Benjamin-L/tracing"
+branch = "tracing-subscriber/env-filter-clone-0.1.x-backport"
+[patch.crates-io.tracing-core]
+git = "https://github.com/Benjamin-L/tracing"
+branch = "tracing-subscriber/env-filter-clone-0.1.x-backport"
+
 [features]
 default = [
     "backend_rocksdb",
@@ -372,6 +386,10 @@ perf_measurements = [
     "opentelemetry_sdk",
     "opentelemetry-jaeger",
 ]
+
+# enable the tokio_console server
+# incompatible with release_max_log_level
+tokio_console = ["console-subscriber", "tokio/tracing"]
 
 hot_reload = ["dep:hot-lib-reloader"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,13 +343,13 @@ hardened_malloc-rs = { version = "0.1.2", optional = true, features = [
 # backport of [https://github.com/tokio-rs/tracing/pull/2956] to the 0.1.x branch of tracing.
 # we can switch back to upstream if #2956 is merged and backported in the upstream repo.
 [patch.crates-io.tracing-subscriber]
-git = "https://github.com/Benjamin-L/tracing"
+git = "https://github.com/girlbossceo/tracing"
 branch = "tracing-subscriber/env-filter-clone-0.1.x-backport"
 [patch.crates-io.tracing]
-git = "https://github.com/Benjamin-L/tracing"
+git = "https://github.com/girlbossceo/tracing"
 branch = "tracing-subscriber/env-filter-clone-0.1.x-backport"
 [patch.crates-io.tracing-core]
-git = "https://github.com/Benjamin-L/tracing"
+git = "https://github.com/girlbossceo/tracing"
 branch = "tracing-subscriber/env-filter-clone-0.1.x-backport"
 
 [features]

--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -473,7 +473,7 @@ allow_profile_lookup_federation_requests = true
 # Maximum entries stored in DNS memory-cache. The size of an entry may vary so please take care if
 # raising this value excessively. Only decrease this when using an external DNS cache. Please note
 # that systemd does *not* count as an external cache, even when configured to do so.
-#dns_cache_entries = 12288
+#dns_cache_entries = 32768
 
 # Minimum time-to-live in seconds for entries in the DNS cache. The default may appear high to most
 # administrators; this is by design. Only decrease this if you are using an external DNS cache.

--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -482,7 +482,9 @@ allow_profile_lookup_federation_requests = true
 # Minimum time-to-live in seconds for NXDOMAIN entries in the DNS cache. This value is critical for
 # the server to federate efficiently. NXDOMAIN's are assumed to not be returning to the federation
 # and aggressively cached rather than constantly rechecked.
-#dns_min_ttl_nxdomain = 86400
+#
+# Defaults to 3 days as these are *very rarely* false negatives.
+#dns_min_ttl_nxdomain = 259200
 
 # The number of seconds to wait for a reply to a DNS query. Please note that recursive queries can
 # take up to several seconds for some domains, so this value should not be too low.

--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -336,6 +336,18 @@ allow_profile_lookup_federation_requests = true
 # messages without any attempt at redelivery.
 #startup_netburst_keep = 50
 
+# If the 'perf_measurements' feature is enabled, enables collecting folded stack trace profile of tracing spans using
+# tracing_flame. The resulting profile can be visualized with inferno[1], speedscope[2], or a number of other tools.
+# [1]: https://github.com/jonhoo/inferno
+# [2]: www.speedscope.app
+# tracing_flame = false
+
+# If 'tracing_flame' is enabled, sets a filter for which events will be included in the profile.
+# Supported syntax is documented at https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+# tracing_flame_filter = "trace,h2=off"
+
+# If 'tracing_flame' is enabled, set the path to write the generated profile.
+# tracing_flame_output_path = "./tracing.folded"
 
 ### Generic database options
 

--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -400,10 +400,12 @@ allow_profile_lookup_federation_requests = true
 #rocksdb_max_log_files = 3
 
 # Type of RocksDB database compression to use.
-# Available options are "zstd", "zlib", "bz2" and "lz4"
+# Available options are "zstd", "zlib", "bz2", "lz4", or "none"
 # It is best to use ZSTD as an overall good balance between speed/performance, storage, IO amplification, and CPU usage.
 # For more performance but less compression (more storage used) and less CPU usage, use LZ4.
 # See https://github.com/facebook/rocksdb/wiki/Compression for more details.
+#
+# "none" will disable compression.
 #
 # Defaults to "zstd"
 #rocksdb_compression_algo = "zstd"

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,3 +2,21 @@
 
 Information about developing the project. If you are only interested in using
 it, you can safely ignore this section.
+
+## Debugging with `tokio-console`
+
+[`tokio-console`][1] can be a useful tool for debugging and profiling. To make
+a `tokio-console`-enabled build of Conduwuit, enable the `tokio_console` feature,
+disable the default `release_max_log_level` feature, and set the
+`--cfg tokio_unstable` flag to enable experimental tokio APIs. A build might
+look like this:
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable" cargo build \
+    --release \
+    --no-default-features \
+    --features
+    backend_rocksdb,systemd,element_hacks,sentry_telemetry,gzip_compression,brotli_compression,zstd_compression,tokio_console
+```
+
+[1]: https://docs.rs/tokio-console/latest/tokio_console/

--- a/src/api/client_server/account.rs
+++ b/src/api/client_server/account.rs
@@ -294,7 +294,8 @@ pub(crate) async fn register_route(body: Ruma<register::v3::Request>) -> Result<
 			.admin
 			.send_message(RoomMessageEventContent::notice_plain(format!(
 				"New user \"{user_id}\" registered on this server."
-			)));
+			)))
+			.await;
 	}
 
 	// log in conduit admin channel if a guest registered
@@ -310,27 +311,30 @@ pub(crate) async fn register_route(body: Ruma<register::v3::Request>) -> Result<
 					.send_message(RoomMessageEventContent::notice_plain(format!(
 						"Guest user \"{user_id}\" with device display name `{device_display_name}` registered on this \
 						 server."
-					)));
+					)))
+					.await;
 			} else {
 				services()
 					.admin
 					.send_message(RoomMessageEventContent::notice_plain(format!(
 						"Guest user \"{user_id}\" with no device display name registered on this server.",
-					)));
+					)))
+					.await;
 			}
 		} else {
 			services()
 				.admin
 				.send_message(RoomMessageEventContent::notice_plain(format!(
 					"Guest user \"{user_id}\" with no device display name registered on this server.",
-				)));
+				)))
+				.await;
 		}
 	}
 
 	// If this is the first real user, grant them admin privileges except for guest
 	// users Note: the server user, @conduit:servername, is generated first
 	if !is_guest {
-		if let Some(admin_room) = service::admin::Service::get_admin_room()? {
+		if let Some(admin_room) = service::admin::Service::get_admin_room().await? {
 			if services()
 				.rooms
 				.state_cache
@@ -461,7 +465,8 @@ pub(crate) async fn change_password_route(
 		.admin
 		.send_message(RoomMessageEventContent::notice_plain(format!(
 			"User {sender_user} changed their password."
-		)));
+		)))
+		.await;
 
 	Ok(change_password::v3::Response {})
 }
@@ -536,7 +541,8 @@ pub(crate) async fn deactivate_route(body: Ruma<deactivate::v3::Request>) -> Res
 		.admin
 		.send_message(RoomMessageEventContent::notice_plain(format!(
 			"User {sender_user} deactivated their account."
-		)));
+		)))
+		.await;
 
 	Ok(deactivate::v3::Response {
 		id_server_unbind_result: ThirdPartyIdRemovalStatus::NoSupport,

--- a/src/api/client_server/message.rs
+++ b/src/api/client_server/message.rs
@@ -159,7 +159,9 @@ pub(crate) async fn get_message_events_route(
 		.lazy_load_confirm_delivery(sender_user, sender_device, &body.room_id, from)
 		.await?;
 
-	let limit = u64::from(body.limit).min(100) as usize;
+	let limit = u64::from(body.limit)
+		.min(body.filter.limit.map_or(u64::MAX, u64::from))
+		.min(100) as usize;
 
 	let next_token;
 

--- a/src/api/client_server/message.rs
+++ b/src/api/client_server/message.rs
@@ -6,13 +6,12 @@ use std::{
 use ruma::{
 	api::client::{
 		error::ErrorKind,
-		filter::{RoomEventFilter, UrlFilter},
 		message::{get_message_events, send_message_event},
 	},
 	events::{MessageLikeEventType, StateEventType},
 	RoomId, UserId,
 };
-use serde_json::{from_str, Value};
+use serde_json::from_str;
 
 use crate::{
 	service::{pdu::PduBuilder, rooms::timeline::PduCount},
@@ -176,7 +175,7 @@ pub(crate) async fn get_message_events_route(
 				.timeline
 				.pdus_after(sender_user, &body.room_id, from)?
 				.filter_map(Result::ok) // Filter out buggy events
-				.filter(|(_, pdu)| contains_url_filter(pdu, &body.filter))
+				.filter(|(_, pdu)| filter.pdu_event_allowed(pdu))
 				.filter(|(_, pdu)| visibility_filter(pdu, sender_user, &body.room_id))
 				.take_while(|&(k, _)| Some(k) != to) // Stop at `to`
 				.take(limit)
@@ -222,7 +221,7 @@ pub(crate) async fn get_message_events_route(
 				.timeline
 				.pdus_until(sender_user, &body.room_id, from)?
 				.filter_map(Result::ok) // Filter out buggy events
-				.filter(|(_, pdu)| contains_url_filter(pdu, &body.filter))
+				.filter(|(_, pdu)| filter.pdu_event_allowed(pdu))
 				.filter(|(_, pdu)| visibility_filter(pdu, sender_user, &body.room_id))
 				.take_while(|&(k, _)| Some(k) != to) // Stop at `to`
 				.take(limit)
@@ -290,17 +289,4 @@ fn visibility_filter(pdu: &PduEvent, user_id: &UserId, room_id: &RoomId) -> bool
 		.state_accessor
 		.user_can_see_event(user_id, room_id, &pdu.event_id)
 		.unwrap_or(false)
-}
-
-fn contains_url_filter(pdu: &PduEvent, filter: &RoomEventFilter) -> bool {
-	if filter.url_filter.is_none() {
-		return true;
-	}
-
-	let content: Value = from_str(pdu.content.get()).unwrap();
-	match filter.url_filter {
-		Some(UrlFilter::EventsWithoutUrl) => !content["url"].is_string(),
-		Some(UrlFilter::EventsWithUrl) => content["url"].is_string(),
-		None => true,
-	}
 }

--- a/src/api/client_server/report.rs
+++ b/src/api/client_server/report.rs
@@ -97,7 +97,8 @@ pub(crate) async fn report_event_route(
 				body.score.unwrap_or_else(|| ruma::Int::from(0)),
 				HtmlEscape(body.reason.as_deref().unwrap_or(""))
 			),
-		));
+		))
+		.await;
 
 	// even though this is kinda security by obscurity, let's still make a small
 	// random delay sending a successful response per spec suggestion regarding

--- a/src/api/client_server/state.rs
+++ b/src/api/client_server/state.rs
@@ -239,7 +239,7 @@ async fn send_state_event_for_key_helper(
 		},
 		// admin room is a sensitive room, it should not ever be made public
 		StateEventType::RoomJoinRules => {
-			if let Some(admin_room_id) = service::admin::Service::get_admin_room()? {
+			if let Some(admin_room_id) = service::admin::Service::get_admin_room().await? {
 				if admin_room_id == room_id {
 					if let Ok(join_rule) = serde_json::from_str::<RoomJoinRulesEventContent>(json.json().get()) {
 						if join_rule.join_rule == JoinRule::Public {
@@ -254,7 +254,7 @@ async fn send_state_event_for_key_helper(
 		},
 		// admin room is a sensitive room, it should not ever be made world readable
 		StateEventType::RoomHistoryVisibility => {
-			if let Some(admin_room_id) = service::admin::Service::get_admin_room()? {
+			if let Some(admin_room_id) = service::admin::Service::get_admin_room().await? {
 				if admin_room_id == room_id {
 					if let Ok(visibility_content) =
 						serde_json::from_str::<RoomHistoryVisibilityEventContent>(json.json().get())

--- a/src/api/client_server/sync.rs
+++ b/src/api/client_server/sync.rs
@@ -460,16 +460,16 @@ async fn sync_helper(
 			}
 		};
 
-		left_rooms.insert(
-			room_id.into_owned(),
-			LeftRoom {
-				account_data: RoomAccountData {
-					events: Vec::new(),
-				},
-				timeline,
-				state,
+		let left_room = LeftRoom {
+			account_data: RoomAccountData {
+				events: Vec::new(),
 			},
-		);
+			timeline,
+			state,
+		};
+		if !left_room.is_empty() {
+			left_rooms.insert(room_id.into_owned(), left_room);
+		}
 	}
 
 	let mut invited_rooms = BTreeMap::new();
@@ -519,14 +519,14 @@ async fn sync_helper(
 			continue;
 		}
 
-		invited_rooms.insert(
-			room_id.into_owned(),
-			InvitedRoom {
-				invite_state: InviteState {
-					events: invite_state_events,
-				},
+		let invited_room = InvitedRoom {
+			invite_state: InviteState {
+				events: invite_state_events,
 			},
-		);
+		};
+		if !invited_room.is_empty() {
+			invited_rooms.insert(room_id.into_owned(), invited_room);
+		}
 	}
 
 	for user_id in left_encrypted_users {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -515,8 +515,8 @@ impl fmt::Display for Config {
 			),
 			("Cleanup interval in seconds", &self.cleanup_second_interval.to_string()),
 			("DNS cache entry limit", &self.dns_cache_entries.to_string()),
-			("DNS minimum ttl", &self.dns_min_ttl.to_string()),
-			("DNS minimum nxdomain ttl", &self.dns_min_ttl_nxdomain.to_string()),
+			("DNS minimum TTL", &self.dns_min_ttl.to_string()),
+			("DNS minimum NXDOMAIN TTL", &self.dns_min_ttl_nxdomain.to_string()),
 			("DNS attempts", &self.dns_attempts.to_string()),
 			("DNS timeout", &self.dns_timeout.to_string()),
 			("DNS fallback to TCP", &self.dns_tcp_fallback.to_string()),
@@ -890,7 +890,7 @@ fn default_dns_cache_entries() -> u32 { 12288 }
 
 fn default_dns_min_ttl() -> u64 { 60 * 180 }
 
-fn default_dns_min_ttl_nxdomain() -> u64 { 60 * 60 * 24 }
+fn default_dns_min_ttl_nxdomain() -> u64 { 60 * 60 * 24 * 3 }
 
 fn default_dns_attempts() -> u16 { 10 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -175,6 +175,9 @@ pub(crate) struct Config {
 	#[serde(default)]
 	#[cfg(feature = "perf_measurements")]
 	pub(crate) tracing_flame: bool,
+	#[serde(default = "default_tracing_flame_filter")]
+	#[cfg(feature = "perf_measurements")]
+	pub(crate) tracing_flame_filter: String,
 	#[serde(default)]
 	pub(crate) proxy: ProxyConfig,
 	pub(crate) jwt_secret: Option<String>,
@@ -933,6 +936,9 @@ fn default_appservice_idle_timeout() -> u64 { 300 }
 fn default_pusher_idle_timeout() -> u64 { 15 }
 
 fn default_max_fetch_prev_events() -> u16 { 100_u16 }
+
+#[cfg(feature = "perf_measurements")]
+fn default_tracing_flame_filter() -> String { "trace,h2=off".to_owned() }
 
 fn default_trusted_servers() -> Vec<OwnedServerName> { vec![OwnedServerName::try_from("matrix.org").unwrap()] }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -178,6 +178,9 @@ pub(crate) struct Config {
 	#[serde(default = "default_tracing_flame_filter")]
 	#[cfg(feature = "perf_measurements")]
 	pub(crate) tracing_flame_filter: String,
+	#[serde(default = "default_tracing_flame_output_path")]
+	#[cfg(feature = "perf_measurements")]
+	pub(crate) tracing_flame_output_path: String,
 	#[serde(default)]
 	pub(crate) proxy: ProxyConfig,
 	pub(crate) jwt_secret: Option<String>,
@@ -939,6 +942,9 @@ fn default_max_fetch_prev_events() -> u16 { 100_u16 }
 
 #[cfg(feature = "perf_measurements")]
 fn default_tracing_flame_filter() -> String { "trace,h2=off".to_owned() }
+
+#[cfg(feature = "perf_measurements")]
+fn default_tracing_flame_output_path() -> String { "./tracing.folded".to_owned() }
 
 fn default_trusted_servers() -> Vec<OwnedServerName> { vec![OwnedServerName::try_from("matrix.org").unwrap()] }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -886,7 +886,7 @@ fn default_cleanup_second_interval() -> u32 {
 	1800 // every 30 minutes
 }
 
-fn default_dns_cache_entries() -> u32 { 12288 }
+fn default_dns_cache_entries() -> u32 { 32768 }
 
 fn default_dns_min_ttl() -> u64 { 60 * 180 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -372,7 +372,8 @@ impl KeyValueDatabase {
 						.send_message(RoomMessageEventContent::text_plain(
 							"The Conduit account emergency password is set! Please unset it as soon as you finish \
 							 admin account recovery!",
-						));
+						))
+						.await;
 				}
 			},
 			Err(e) => {
@@ -473,7 +474,8 @@ impl KeyValueDatabase {
 					.send_message(RoomMessageEventContent::text_plain(format!(
 						"@room: the following is a message from the conduwuit puppy. it was sent on '{}':\n\n{}",
 						update.date, update.message
-					)));
+					)))
+					.await;
 			}
 		}
 		services()

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -40,8 +40,8 @@ use tokio::time::{interval, Instant};
 use tracing::{debug, error, warn};
 
 use crate::{
-	database::migrations::migrations, service::rooms::timeline::PduCount, services, Config, Error, Result, Services,
-	SERVICES,
+	database::migrations::migrations, service::rooms::timeline::PduCount, services, Config, Error,
+	LogLevelReloadHandles, Result, Services, SERVICES,
 };
 
 pub(crate) struct KeyValueDatabase {
@@ -203,13 +203,7 @@ struct CheckForUpdatesResponse {
 impl KeyValueDatabase {
 	/// Load an existing database or create a new one.
 	#[allow(clippy::too_many_lines)]
-	pub(crate) async fn load_or_create(
-		config: Config,
-		tracing_reload_handler: tracing_subscriber::reload::Handle<
-			tracing_subscriber::EnvFilter,
-			tracing_subscriber::Registry,
-		>,
-	) -> Result<()> {
+	pub(crate) async fn load_or_create(config: Config, tracing_reload_handler: LogLevelReloadHandles) -> Result<()> {
 		Self::check_db_setup(&config)?;
 
 		if !Path::new(&config.database_path).exists() {

--- a/src/database/rocksdb/opts.rs
+++ b/src/database/rocksdb/opts.rs
@@ -222,7 +222,7 @@ fn set_for_random_small(opts: &mut Options, config: &Config) {
 }
 
 fn set_for_sequential_small(opts: &mut Options, config: &Config) {
-	set_for_random(opts, config);
+	set_for_sequential(opts, config);
 
 	opts.set_write_buffer_size(1024 * 512);
 	opts.set_target_file_size_base(1024 * 512);

--- a/src/database/rocksdb/opts.rs
+++ b/src/database/rocksdb/opts.rs
@@ -22,7 +22,7 @@ pub(crate) fn db_options(config: &Config, env: &mut Env, row_cache: &Cache, col_
 
 	// Processing
 	let threads = if config.rocksdb_parallelism_threads == 0 {
-		num_cpus::get() // max cores if user specified 0
+		std::cmp::max(2, num_cpus::get()) // max cores if user specified 0
 	} else {
 		config.rocksdb_parallelism_threads
 	};

--- a/src/database/rocksdb/opts.rs
+++ b/src/database/rocksdb/opts.rs
@@ -175,9 +175,12 @@ fn set_logging_defaults(opts: &mut Options, config: &Config) {
 
 fn set_compression_defaults(opts: &mut Options, config: &Config) {
 	let rocksdb_compression_algo = match config.rocksdb_compression_algo.as_ref() {
+		"snappy" => DBCompressionType::Snappy,
 		"zlib" => DBCompressionType::Zlib,
-		"lz4" => DBCompressionType::Lz4,
 		"bz2" => DBCompressionType::Bz2,
+		"lz4" => DBCompressionType::Lz4,
+		"lz4hc" => DBCompressionType::Lz4hc,
+		"none" => DBCompressionType::None,
 		_ => DBCompressionType::Zstd,
 	};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -617,7 +617,10 @@ fn init_tracing(config: &Config) -> LogLevelReloadHandles {
 	#[cfg(feature = "perf_measurements")]
 	let subscriber = {
 		let flame_layer = if config.tracing_flame {
-			let flame_filter = EnvFilter::new("trace,h2=off");
+			let flame_filter = match EnvFilter::try_new(&config.tracing_flame_filter) {
+				Ok(flame_filter) => flame_filter,
+				Err(e) => panic!("tracing_flame_filter config value is invalid: {e}"),
+			};
 
 			// TODO: actually preserve this guard until exit: https://docs.rs/tracing-flame/latest/tracing_flame/struct.FlameLayer.html#dropping-and-flushing
 			let (flame_layer, _guard) = tracing_flame::FlameLayer::with_file("./tracing.folded").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,13 @@ fn init_tracing(config: &Config) -> (LogLevelReloadHandles, TracingFlameGuard) {
 				Err(e) => panic!("tracing_flame_filter config value is invalid: {e}"),
 			};
 
-			let (flame_layer, flame_guard) = tracing_flame::FlameLayer::with_file("./tracing.folded").unwrap();
+			let (flame_layer, flame_guard) =
+				match tracing_flame::FlameLayer::with_file(&config.tracing_flame_output_path) {
+					Ok(ok) => ok,
+					Err(e) => {
+						panic!("failed to initialize tracing-flame: {e}");
+					},
+				};
 			let flame_layer = flame_layer
 				.with_empty_samples(false)
 				.with_filter(flame_filter);

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,7 +515,7 @@ fn init(args: clap::Args) -> Result<Server, Error> {
 			.enable_io()
 			.enable_time()
 			.thread_name("conduwuit:worker")
-			.worker_threads(num_cpus::get())
+			.worker_threads(std::cmp::max(2, num_cpus::get()))
 			.build()
 			.unwrap(),
 

--- a/src/service/admin/debug/debug_commands.rs
+++ b/src/service/admin/debug/debug_commands.rs
@@ -331,7 +331,7 @@ pub(crate) async fn change_log_level(
 		match services()
 			.globals
 			.tracing_reload_handle
-			.modify(|filter| *filter = old_filter_layer)
+			.reload(&old_filter_layer)
 		{
 			Ok(()) => {
 				return Ok(RoomMessageEventContent::text_plain(format!(
@@ -360,7 +360,7 @@ pub(crate) async fn change_log_level(
 		match services()
 			.globals
 			.tracing_reload_handle
-			.modify(|filter| *filter = new_filter_layer)
+			.reload(&new_filter_layer)
 		{
 			Ok(()) => {
 				return Ok(RoomMessageEventContent::text_plain("Successfully changed log level"));

--- a/src/service/admin/debug/mod.rs
+++ b/src/service/admin/debug/mod.rs
@@ -3,7 +3,7 @@ use ruma::{events::room::message::RoomMessageEventContent, EventId, RoomId, Serv
 
 use self::debug_commands::{
 	change_log_level, force_device_list_updates, get_auth_chain, get_pdu, get_remote_pdu, get_remote_pdu_list,
-	get_room_state, parse_pdu, ping, sign_json, verify_json,
+	get_room_state, parse_pdu, ping, resolve_true_destination, sign_json, verify_json,
 };
 use crate::Result;
 
@@ -106,6 +106,17 @@ pub(crate) enum DebugCommand {
 	/// This command needs a JSON blob provided in a Markdown code block below
 	/// the command.
 	VerifyJson,
+
+	/// - Runs a server name through conduwuit's true destination resolution
+	///   process
+	///
+	/// Useful for debugging well-known issues
+	ResolveTrueDestination {
+		server_name: Box<ServerName>,
+
+		#[arg(short, long)]
+		no_cache: bool,
+	},
 }
 
 pub(crate) async fn process(command: DebugCommand, body: Vec<&str>) -> Result<RoomMessageEventContent> {
@@ -138,5 +149,9 @@ pub(crate) async fn process(command: DebugCommand, body: Vec<&str>) -> Result<Ro
 			server,
 			force,
 		} => get_remote_pdu_list(body, server, force).await?,
+		DebugCommand::ResolveTrueDestination {
+			server_name,
+			no_cache,
+		} => resolve_true_destination(body, server_name, no_cache).await?,
 	})
 }

--- a/src/service/admin/federation/federation_commands.rs
+++ b/src/service/admin/federation/federation_commands.rs
@@ -1,8 +1,13 @@
 use std::fmt::Write as _;
 
-use ruma::{events::room::message::RoomMessageEventContent, RoomId, ServerName};
+use ruma::{events::room::message::RoomMessageEventContent, OwnedRoomId, RoomId, ServerName, UserId};
 
-use crate::{services, utils::HtmlEscape, Result};
+use crate::{
+	service::admin::{escape_html, get_room_info},
+	services,
+	utils::HtmlEscape,
+	Result,
+};
 
 pub(crate) async fn disable_room(_body: Vec<&str>, room_id: Box<RoomId>) -> Result<RoomMessageEventContent> {
 	services().rooms.metadata.disable_room(&room_id, true)?;
@@ -69,4 +74,61 @@ pub(crate) async fn fetch_support_well_known(
 			HtmlEscape(&pretty_json)
 		),
 	))
+}
+
+pub(crate) async fn remote_user_in_rooms(_body: Vec<&str>, user_id: Box<UserId>) -> Result<RoomMessageEventContent> {
+	if user_id.server_name() == services().globals.config.server_name {
+		return Ok(RoomMessageEventContent::text_plain(
+			"User belongs to our server, please use `list-joined-rooms` user admin command instead.",
+		));
+	}
+
+	if !services().users.exists(&user_id)? {
+		return Ok(RoomMessageEventContent::text_plain(
+			"Remote user does not exist in our database.",
+		));
+	}
+
+	let mut rooms: Vec<(OwnedRoomId, u64, String)> = services()
+		.rooms
+		.state_cache
+		.rooms_joined(&user_id)
+		.filter_map(Result::ok)
+		.map(|room_id| get_room_info(&room_id))
+		.collect();
+
+	if rooms.is_empty() {
+		return Ok(RoomMessageEventContent::text_plain("User is not in any rooms."));
+	}
+
+	rooms.sort_by_key(|r| r.1);
+	rooms.reverse();
+
+	let output_plain = format!(
+		"Rooms {user_id} shares with us:\n{}",
+		rooms
+			.iter()
+			.map(|(id, members, name)| format!("{id}\tMembers: {members}\tName: {name}"))
+			.collect::<Vec<_>>()
+			.join("\n")
+	);
+	let output_html = format!(
+		"<table><caption>Rooms {user_id} shares with \
+		 us</caption>\n<tr><th>id</th>\t<th>members</th>\t<th>name</th></tr>\n{}</table>",
+		rooms
+			.iter()
+			.fold(String::new(), |mut output, (id, members, name)| {
+				writeln!(
+					output,
+					"<tr><td>{}</td>\t<td>{}</td>\t<td>{}</td></tr>",
+					escape_html(id.as_ref()),
+					members,
+					escape_html(name)
+				)
+				.unwrap();
+				output
+			})
+	);
+
+	Ok(RoomMessageEventContent::text_html(output_plain, output_html))
 }

--- a/src/service/admin/federation/mod.rs
+++ b/src/service/admin/federation/mod.rs
@@ -1,7 +1,9 @@
 use clap::Subcommand;
-use ruma::{events::room::message::RoomMessageEventContent, RoomId, ServerName};
+use ruma::{events::room::message::RoomMessageEventContent, RoomId, ServerName, UserId};
 
-use self::federation_commands::{disable_room, enable_room, fetch_support_well_known, incoming_federeation};
+use self::federation_commands::{
+	disable_room, enable_room, fetch_support_well_known, incoming_federeation, remote_user_in_rooms,
+};
 use crate::Result;
 
 pub(crate) mod federation_commands;
@@ -34,6 +36,11 @@ pub(crate) enum FederationCommand {
 	FetchSupportWellKnown {
 		server_name: Box<ServerName>,
 	},
+
+	/// - Lists all the rooms we share/track with the specified *remote* user
+	RemoteUserInRooms {
+		user_id: Box<UserId>,
+	},
 }
 
 pub(crate) async fn process(command: FederationCommand, body: Vec<&str>) -> Result<RoomMessageEventContent> {
@@ -48,5 +55,8 @@ pub(crate) async fn process(command: FederationCommand, body: Vec<&str>) -> Resu
 		FederationCommand::FetchSupportWellKnown {
 			server_name,
 		} => fetch_support_well_known(body, server_name).await?,
+		FederationCommand::RemoteUserInRooms {
+			user_id,
+		} => remote_user_in_rooms(body, user_id).await?,
 	})
 }

--- a/src/service/admin/room/room_moderation_commands.rs
+++ b/src/service/admin/room/room_moderation_commands.rs
@@ -25,7 +25,7 @@ pub(crate) async fn process(command: RoomModerationCommand, body: Vec<&str>) -> 
 				.try_into()
 				.expect("#admins:server_name is a valid alias name");
 
-			if let Some(admin_room_id) = Service::get_admin_room()? {
+			if let Some(admin_room_id) = Service::get_admin_room().await? {
 				if room.to_string().eq(&admin_room_id) || room.to_string().eq(&admin_room_alias) {
 					return Ok(RoomMessageEventContent::text_plain("Not allowed to ban the admin room."));
 				}
@@ -190,7 +190,7 @@ pub(crate) async fn process(command: RoomModerationCommand, body: Vec<&str>) -> 
 				for &room in &rooms_s {
 					match <&RoomOrAliasId>::try_from(room) {
 						Ok(room_alias_or_id) => {
-							if let Some(admin_room_id) = Service::get_admin_room()? {
+							if let Some(admin_room_id) = Service::get_admin_room().await? {
 								if room.to_owned().eq(&admin_room_id) || room.to_owned().eq(&admin_room_alias) {
 									info!("User specified admin room in bulk ban list, ignoring");
 									continue;

--- a/src/service/admin/user/user_commands.rs
+++ b/src/service/admin/user/user_commands.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Write as _, sync::Arc};
 
-use itertools::Itertools;
 use ruma::{events::room::message::RoomMessageEventContent, OwnedRoomId, UserId};
 use tracing::{error, info, warn};
 
@@ -318,8 +317,6 @@ pub(crate) async fn list_joined_rooms(_body: Vec<&str>, user_id: String) -> Resu
 		.rooms_joined(&user_id)
 		.filter_map(Result::ok)
 		.map(|room_id| get_room_info(&room_id))
-		.sorted_unstable()
-		.dedup()
 		.collect();
 
 	if rooms.is_empty() {

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -27,10 +27,9 @@ use ruma::{
 };
 use tokio::sync::{broadcast, watch::Receiver, Mutex, RwLock};
 use tracing::{error, info, trace};
-use tracing_subscriber::{EnvFilter, Registry};
 use url::Url;
 
-use crate::{services, Config, Result};
+use crate::{services, Config, LogLevelReloadHandles, Result};
 
 mod client;
 mod data;
@@ -45,7 +44,7 @@ type SyncHandle = (
 pub(crate) struct Service<'a> {
 	pub(crate) db: &'static dyn Data,
 
-	pub(crate) tracing_reload_handle: tracing_subscriber::reload::Handle<EnvFilter, Registry>,
+	pub(crate) tracing_reload_handle: LogLevelReloadHandles,
 	pub(crate) config: Config,
 	pub(crate) cidr_range_denylist: Vec<IPAddress>,
 	keypair: Arc<ruma::signatures::Ed25519KeyPair>,
@@ -99,8 +98,7 @@ impl Default for RotationHandler {
 
 impl Service<'_> {
 	pub(crate) fn load(
-		db: &'static dyn Data, config: &Config,
-		tracing_reload_handle: tracing_subscriber::reload::Handle<EnvFilter, Registry>,
+		db: &'static dyn Data, config: &Config, tracing_reload_handle: LogLevelReloadHandles,
 	) -> Result<Self> {
 		let keypair = db.load_keypair();
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -6,7 +6,7 @@ use std::{
 use lru_cache::LruCache;
 use tokio::sync::{broadcast, Mutex, RwLock};
 
-use crate::{Config, Result};
+use crate::{Config, LogLevelReloadHandles, Result};
 
 pub(crate) mod account_data;
 pub(crate) mod admin;
@@ -55,11 +55,7 @@ impl Services<'_> {
 			+ sending::Data
 			+ 'static,
 	>(
-		db: &'static D, config: &Config,
-		tracing_reload_handle: tracing_subscriber::reload::Handle<
-			tracing_subscriber::EnvFilter,
-			tracing_subscriber::Registry,
-		>,
+		db: &'static D, config: &Config, tracing_reload_handle: LogLevelReloadHandles,
 	) -> Result<Self> {
 		Ok(Self {
 			appservice: appservice::Service::build(db)?,

--- a/src/service/rooms/timeline/mod.rs
+++ b/src/service/rooms/timeline/mod.rs
@@ -512,9 +512,12 @@ impl Service {
 					// the administrator can execute commands as conduit
 					let from_conduit = pdu.sender == server_user && services().globals.emergency_password().is_none();
 
-					if let Some(admin_room) = service::admin::Service::get_admin_room()? {
+					if let Some(admin_room) = service::admin::Service::get_admin_room().await? {
 						if to_conduit && !from_conduit && admin_room == pdu.room_id {
-							services().admin.process_message(body, pdu.event_id.clone());
+							services()
+								.admin
+								.process_message(body, pdu.event_id.clone())
+								.await;
 						}
 					}
 				}
@@ -815,7 +818,7 @@ impl Service {
 	) -> Result<Arc<EventId>> {
 		let (pdu, pdu_json) = self.create_hash_and_sign_event(pdu_builder, sender, room_id, state_lock)?;
 
-		if let Some(admin_room) = service::admin::Service::get_admin_room()? {
+		if let Some(admin_room) = service::admin::Service::get_admin_room().await? {
 			if admin_room == room_id {
 				match pdu.event_type() {
 					TimelineEventType::RoomEncryption => {

--- a/src/service/sending/mod.rs
+++ b/src/service/sending/mod.rs
@@ -12,8 +12,8 @@ use crate::{services, Config, Error, Result};
 
 mod appservice;
 mod data;
-mod send;
-mod sender;
+pub(crate) mod send;
+pub(crate) mod sender;
 pub(crate) use send::FedDest;
 
 pub(crate) struct Service {

--- a/src/service/sending/send.rs
+++ b/src/service/sending/send.rs
@@ -221,9 +221,9 @@ pub(crate) async fn resolve_actual_dest(
 	if admin_room_caller {
 		services()
 			.admin
-			.send_message(RoomMessageEventContent::notice_plain(format!(
-				"Checking for 1: IP literal with provided or default port"
-			)))
+			.send_message(RoomMessageEventContent::notice_plain(
+				"Checking for 1: IP literal with provided or default port",
+			))
 			.await;
 	}
 
@@ -313,9 +313,9 @@ pub(crate) async fn resolve_actual_dest(
 							if admin_room_caller {
 								services()
 									.admin
-									.send_message(RoomMessageEventContent::notice_plain(format!(
-										"Checking for 3.2: Hostname with port in .well-known file"
-									)))
+									.send_message(RoomMessageEventContent::notice_plain(
+										"Checking for 3.2: Hostname with port in .well-known file",
+									))
 									.await;
 							}
 

--- a/src/service/sending/send.rs
+++ b/src/service/sending/send.rs
@@ -433,7 +433,8 @@ fn handle_resolve_error(e: &ResolveError) -> Result<()> {
 		ResolveErrorKind::NoRecordsFound {
 			..
 		} => {
-			debug_warn!("{e}");
+			// Raise to debug_warn if we can find out the result wasn't from cache
+			debug!("{e}");
 			Ok(())
 		},
 		_ => {

--- a/src/service/sending/send.rs
+++ b/src/service/sending/send.rs
@@ -13,6 +13,7 @@ use ruma::{
 		client::error::Error as RumaError, EndpointError, IncomingResponse, MatrixVersion, OutgoingRequest,
 		SendAccessToken,
 	},
+	events::room::message::RoomMessageEventContent,
 	OwnedServerName, ServerName,
 };
 use tracing::{debug, error, trace};
@@ -194,7 +195,7 @@ async fn get_actual_dest(server_name: &ServerName) -> Result<ActualDest> {
 	} else {
 		cached = false;
 		validate_dest(server_name)?;
-		resolve_actual_dest(server_name).await?
+		resolve_actual_dest(server_name, false, false).await?
 	};
 
 	let string = dest.clone().into_https_string();
@@ -210,59 +211,220 @@ async fn get_actual_dest(server_name: &ServerName) -> Result<ActualDest> {
 /// Implemented according to the specification at <https://matrix.org/docs/spec/server_server/r0.1.4#resolving-server-names>
 /// Numbers in comments below refer to bullet points in linked section of
 /// specification
-async fn resolve_actual_dest(dest: &'_ ServerName) -> Result<(FedDest, String)> {
+pub(crate) async fn resolve_actual_dest(
+	dest: &'_ ServerName, no_cache_dest: bool, admin_room_caller: bool,
+) -> Result<(FedDest, String)> {
 	trace!("Finding actual destination for {dest}");
 	let dest_str = dest.as_str().to_owned();
 	let mut hostname = dest_str.clone();
+
+	if admin_room_caller {
+		services()
+			.admin
+			.send_message(RoomMessageEventContent::notice_plain(format!(
+				"Checking for 1: IP literal with provided or default port"
+			)))
+			.await;
+	}
+
+	#[allow(clippy::single_match_else)]
 	let actual_dest = match get_ip_with_port(&dest_str) {
 		Some(host_port) => {
 			debug!("1: IP literal with provided or default port");
+			if admin_room_caller {
+				services()
+					.admin
+					.send_message(RoomMessageEventContent::notice_plain(format!(
+						"1: IP literal with provided or default port\n\nHost and Port: {host_port:?}"
+					)))
+					.await;
+			}
+
 			host_port
 		},
 		None => {
+			if admin_room_caller {
+				services()
+					.admin
+					.send_message(RoomMessageEventContent::notice_plain(
+						"Checking for 2: Hostname with included port",
+					))
+					.await;
+			}
+
 			if let Some(pos) = dest_str.find(':') {
 				debug!("2: Hostname with included port");
+				if admin_room_caller {
+					services()
+						.admin
+						.send_message(RoomMessageEventContent::notice_plain("2: Hostname with included port"))
+						.await;
+				}
 
 				let (host, port) = dest_str.split_at(pos);
-				query_and_cache_override(host, host, port.parse::<u16>().unwrap_or(8448)).await?;
+				if !no_cache_dest {
+					query_and_cache_override(host, host, port.parse::<u16>().unwrap_or(8448)).await?;
+				}
+
+				if admin_room_caller {
+					services()
+						.admin
+						.send_message(RoomMessageEventContent::notice_plain(format!("Host: {host} | Port: {port}")))
+						.await;
+				}
 
 				FedDest::Named(host.to_owned(), port.to_owned())
 			} else {
 				trace!("Requesting well known for {dest}");
+				if admin_room_caller {
+					services()
+						.admin
+						.send_message(RoomMessageEventContent::notice_plain(format!(
+							"Checking for 3: A .well-known file is available. Requesting well-known for {dest}"
+						)))
+						.await;
+				}
+
 				if let Some(delegated_hostname) = request_well_known(dest.as_str()).await? {
 					debug!("3: A .well-known file is available");
+					if admin_room_caller {
+						services()
+							.admin
+							.send_message(RoomMessageEventContent::notice_plain("3: A .well-known file is available"))
+							.await;
+					}
+
 					hostname = add_port_to_hostname(&delegated_hostname).into_uri_string();
 					match get_ip_with_port(&delegated_hostname) {
-						Some(host_and_port) => host_and_port, // 3.1: IP literal in .well-known file
+						Some(host_and_port) => {
+							debug!("3.1: IP literal in .well-known file");
+							if admin_room_caller {
+								services()
+									.admin
+									.send_message(RoomMessageEventContent::notice_plain(format!(
+										"3.1: IP literal in .well-known file\n\nHost and Port: {host_and_port:?}"
+									)))
+									.await;
+							}
+
+							host_and_port
+						},
 						None => {
+							if admin_room_caller {
+								services()
+									.admin
+									.send_message(RoomMessageEventContent::notice_plain(format!(
+										"Checking for 3.2: Hostname with port in .well-known file"
+									)))
+									.await;
+							}
+
 							if let Some(pos) = delegated_hostname.find(':') {
 								debug!("3.2: Hostname with port in .well-known file");
+								if admin_room_caller {
+									services()
+										.admin
+										.send_message(RoomMessageEventContent::notice_plain(
+											"3.2: Hostname with port in .well-known file",
+										))
+										.await;
+								}
 
 								let (host, port) = delegated_hostname.split_at(pos);
-								query_and_cache_override(host, host, port.parse::<u16>().unwrap_or(8448)).await?;
+								if !no_cache_dest {
+									query_and_cache_override(host, host, port.parse::<u16>().unwrap_or(8448)).await?;
+								}
+
+								if admin_room_caller {
+									services()
+										.admin
+										.send_message(RoomMessageEventContent::notice_plain(format!(
+											"Host: {host} | Port: {port}"
+										)))
+										.await;
+								}
 
 								FedDest::Named(host.to_owned(), port.to_owned())
 							} else {
 								trace!("Delegated hostname has no port in this branch");
+								if admin_room_caller {
+									services()
+										.admin
+										.send_message(RoomMessageEventContent::notice_plain(
+											"Delegated hostname has no port specified",
+										))
+										.await;
+								}
+
 								if let Some(hostname_override) = query_srv_record(&delegated_hostname).await? {
 									debug!("3.3: SRV lookup successful");
+									if admin_room_caller {
+										services()
+											.admin
+											.send_message(RoomMessageEventContent::notice_plain(
+												"3.3: SRV lookup successful",
+											))
+											.await;
+									}
 
 									let force_port = hostname_override.port();
-									query_and_cache_override(
-										&delegated_hostname,
-										&hostname_override.hostname(),
-										force_port.unwrap_or(8448),
-									)
-									.await?;
+									if !no_cache_dest {
+										query_and_cache_override(
+											&delegated_hostname,
+											&hostname_override.hostname(),
+											force_port.unwrap_or(8448),
+										)
+										.await?;
+									}
 
 									if let Some(port) = force_port {
+										if admin_room_caller {
+											services()
+												.admin
+												.send_message(RoomMessageEventContent::notice_plain(format!(
+													"Host: {delegated_hostname} | Port: {port}"
+												)))
+												.await;
+										}
+
 										FedDest::Named(delegated_hostname, format!(":{port}"))
 									} else {
+										if admin_room_caller {
+											services()
+												.admin
+												.send_message(RoomMessageEventContent::notice_plain(format!(
+													"Host: {delegated_hostname} | Port: 8448"
+												)))
+												.await;
+										}
+
 										add_port_to_hostname(&delegated_hostname)
 									}
 								} else {
 									debug!("3.4: No SRV records, just use the hostname from .well-known");
-									query_and_cache_override(&delegated_hostname, &delegated_hostname, 8448).await?;
+									if admin_room_caller {
+										services()
+											.admin
+											.send_message(RoomMessageEventContent::notice_plain(
+												"3.4: No SRV records, just use the hostname from .well-known",
+											))
+											.await;
+									}
+
+									if !no_cache_dest {
+										query_and_cache_override(&delegated_hostname, &delegated_hostname, 8448)
+											.await?;
+									}
+
+									if admin_room_caller {
+										services()
+											.admin
+											.send_message(RoomMessageEventContent::notice_plain(format!(
+												"Host: {delegated_hostname} | Port: 8448"
+											)))
+											.await;
+									}
+
 									add_port_to_hostname(&delegated_hostname)
 								}
 							}
@@ -270,21 +432,84 @@ async fn resolve_actual_dest(dest: &'_ ServerName) -> Result<(FedDest, String)> 
 					}
 				} else {
 					trace!("4: No .well-known or an error occured");
+					if admin_room_caller {
+						services()
+							.admin
+							.send_message(RoomMessageEventContent::notice_plain(
+								"4: No .well-known or an error occured",
+							))
+							.await;
+					}
+
 					if let Some(hostname_override) = query_srv_record(&dest_str).await? {
 						debug!("4: No .well-known; SRV record found");
+						if admin_room_caller {
+							services()
+								.admin
+								.send_message(RoomMessageEventContent::notice_plain(
+									"4: No .well-known; SRV record found",
+								))
+								.await;
+						}
 
 						let force_port = hostname_override.port();
-						query_and_cache_override(&hostname, &hostname_override.hostname(), force_port.unwrap_or(8448))
+
+						if !no_cache_dest {
+							query_and_cache_override(
+								&hostname,
+								&hostname_override.hostname(),
+								force_port.unwrap_or(8448),
+							)
 							.await?;
+						}
 
 						if let Some(port) = force_port {
+							if admin_room_caller {
+								services()
+									.admin
+									.send_message(RoomMessageEventContent::notice_plain(format!(
+										"Host: {hostname} | Port: {port}"
+									)))
+									.await;
+							}
+
 							FedDest::Named(hostname.clone(), format!(":{port}"))
 						} else {
+							if admin_room_caller {
+								services()
+									.admin
+									.send_message(RoomMessageEventContent::notice_plain(format!(
+										"Host: {hostname} | Port: 8448"
+									)))
+									.await;
+							}
+
 							add_port_to_hostname(&hostname)
 						}
 					} else {
 						debug!("4: No .well-known; 5: No SRV record found");
-						query_and_cache_override(&dest_str, &dest_str, 8448).await?;
+						if admin_room_caller {
+							services()
+								.admin
+								.send_message(RoomMessageEventContent::notice_plain(
+									"4: No .well-known; 5: No SRV record found",
+								))
+								.await;
+						}
+
+						if !no_cache_dest {
+							query_and_cache_override(&dest_str, &dest_str, 8448).await?;
+						}
+
+						if admin_room_caller {
+							services()
+								.admin
+								.send_message(RoomMessageEventContent::notice_plain(format!(
+									"Host: {dest_str} | Port: 8448"
+								)))
+								.await;
+						}
+
 						add_port_to_hostname(&dest_str)
 					}
 				}
@@ -306,6 +531,14 @@ async fn resolve_actual_dest(dest: &'_ ServerName) -> Result<(FedDest, String)> 
 	};
 
 	debug!("Actual destination: {actual_dest:?} hostname: {hostname:?}");
+	if admin_room_caller {
+		services()
+			.admin
+			.send_message(RoomMessageEventContent::notice_plain(format!(
+				"Actual destination: {actual_dest:?} | Hostname: {hostname:?}"
+			)))
+			.await;
+	}
 	Ok((actual_dest, hostname.into_uri_string()))
 }
 

--- a/src/utils/filter.rs
+++ b/src/utils/filter.rs
@@ -1,0 +1,84 @@
+//! Helper tools for implementing filtering in the `/client/v3/sync` and
+//! `/client/v3/rooms/:roomId/messages` endpoints.
+//!
+//! The default strategy for filtering is to generate all events, check them
+//! against the filter, and drop events that were rejected. When significant
+//! fraction of events are rejected, this results in a large amount of wasted
+//! work computing events that will be dropped. In most cases, the structure of
+//! our database doesn't allow for anything fancier, with only a few exceptions.
+//!
+//! The first exception is room filters (`room`/`not_room` pairs in
+//! `filter.rooms` and `filter.rooms.{account_data,timeline,ephemeral,state}`).
+//! In `/messages`, if the room is rejected by the filter, we can skip the
+//! entire request.
+
+use std::{collections::HashSet, hash::Hash};
+
+use ruma::{api::client::filter::RoomEventFilter, RoomId};
+
+use crate::Error;
+
+/// Structure for testing against an allowlist and a denylist with a single
+/// `HashSet` lookup.
+///
+/// The denylist takes precedence (an item included in both the allowlist and
+/// the denylist is denied).
+pub(crate) enum AllowDenyList<'a, T: ?Sized> {
+	/// TODO: fast-paths for allow-all and deny-all?
+	Allow(HashSet<&'a T>),
+	Deny(HashSet<&'a T>),
+}
+
+impl<'a, T: ?Sized + Hash + PartialEq + Eq> AllowDenyList<'a, T> {
+	fn new<A, D>(allow: Option<A>, deny: D) -> AllowDenyList<'a, T>
+	where
+		A: Iterator<Item = &'a T>,
+		D: Iterator<Item = &'a T>,
+	{
+		let deny_set = deny.collect::<HashSet<_>>();
+		if let Some(allow) = allow {
+			AllowDenyList::Allow(allow.filter(|x| !deny_set.contains(x)).collect())
+		} else {
+			AllowDenyList::Deny(deny_set)
+		}
+	}
+
+	fn from_slices<O: AsRef<T>>(allow: Option<&'a [O]>, deny: &'a [O]) -> AllowDenyList<'a, T> {
+		AllowDenyList::new(
+			allow.map(|allow| allow.iter().map(AsRef::as_ref)),
+			deny.iter().map(AsRef::as_ref),
+		)
+	}
+
+	pub(crate) fn allowed(&self, value: &T) -> bool {
+		match self {
+			AllowDenyList::Allow(allow) => allow.contains(value),
+			AllowDenyList::Deny(deny) => !deny.contains(value),
+		}
+	}
+}
+
+pub(crate) struct CompiledRoomEventFilter<'a> {
+	rooms: AllowDenyList<'a, RoomId>,
+}
+
+impl<'a> TryFrom<&'a RoomEventFilter> for CompiledRoomEventFilter<'a> {
+	type Error = Error;
+
+	fn try_from(source: &'a RoomEventFilter) -> Result<CompiledRoomEventFilter<'a>, Error> {
+		Ok(CompiledRoomEventFilter {
+			rooms: AllowDenyList::from_slices(source.rooms.as_deref(), &source.not_rooms),
+		})
+	}
+}
+
+impl CompiledRoomEventFilter<'_> {
+	/// Returns `true` if a room is allowed by the `rooms` and `not_rooms`
+	/// fields.
+	///
+	/// This does *not* test the room against the top-level `rooms` filter.
+	/// It is expected that callers have already filtered rooms that are
+	/// rejected by the top-level filter using
+	/// [`CompiledRoomFilter::room_allowed`], if applicable.
+	pub(crate) fn room_allowed(&self, room_id: &RoomId) -> bool { self.rooms.allowed(room_id) }
+}

--- a/src/utils/filter.rs
+++ b/src/utils/filter.rs
@@ -12,7 +12,9 @@
 //! In `/messages`, if the room is rejected by the filter, we can skip the
 //! entire request. The outer loop of our `/sync` implementation is over rooms,
 //! and so we are able to skip work for an entire room if it is rejected by the
-//! top-level `filter.rooms.room`.
+//! top-level `filter.rooms.room`. Similarly, when a room is rejected for all
+//! events in a particular category, we can skip work generating events in that
+//! category for the rejected room.
 
 use std::{collections::HashSet, hash::Hash};
 
@@ -134,6 +136,7 @@ pub(crate) struct CompiledFilterDefinition<'a> {
 
 pub(crate) struct CompiledRoomFilter<'a> {
 	rooms: AllowDenyList<'a, RoomId>,
+	pub(crate) timeline: CompiledRoomEventFilter<'a>,
 }
 
 pub(crate) struct CompiledRoomEventFilter<'a> {
@@ -163,6 +166,7 @@ impl<'a> TryFrom<&'a RoomFilter> for CompiledRoomFilter<'a> {
 			// TODO: consider calculating the intersection of room filters in
 			// all of the sub-filters
 			rooms: AllowDenyList::from_slices(source.rooms.as_deref(), &source.not_rooms),
+			timeline: (&source.timeline).try_into()?,
 		})
 	}
 }

--- a/src/utils/filter.rs
+++ b/src/utils/filter.rs
@@ -137,6 +137,7 @@ pub(crate) struct CompiledFilterDefinition<'a> {
 pub(crate) struct CompiledRoomFilter<'a> {
 	rooms: AllowDenyList<'a, RoomId>,
 	pub(crate) timeline: CompiledRoomEventFilter<'a>,
+	pub(crate) ephemeral: CompiledRoomEventFilter<'a>,
 	pub(crate) state: CompiledRoomEventFilter<'a>,
 }
 
@@ -168,6 +169,7 @@ impl<'a> TryFrom<&'a RoomFilter> for CompiledRoomFilter<'a> {
 			// all of the sub-filters
 			rooms: AllowDenyList::from_slices(source.rooms.as_deref(), &source.not_rooms),
 			timeline: (&source.timeline).try_into()?,
+			ephemeral: (&source.ephemeral).try_into()?,
 			state: (&source.state).try_into()?,
 		})
 	}

--- a/src/utils/filter.rs
+++ b/src/utils/filter.rs
@@ -137,6 +137,7 @@ pub(crate) struct CompiledFilterDefinition<'a> {
 pub(crate) struct CompiledRoomFilter<'a> {
 	rooms: AllowDenyList<'a, RoomId>,
 	pub(crate) timeline: CompiledRoomEventFilter<'a>,
+	pub(crate) state: CompiledRoomEventFilter<'a>,
 }
 
 pub(crate) struct CompiledRoomEventFilter<'a> {
@@ -167,6 +168,7 @@ impl<'a> TryFrom<&'a RoomFilter> for CompiledRoomFilter<'a> {
 			// all of the sub-filters
 			rooms: AllowDenyList::from_slices(source.rooms.as_deref(), &source.not_rooms),
 			timeline: (&source.timeline).try_into()?,
+			state: (&source.state).try_into()?,
 		})
 	}
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod clap;
 pub(crate) mod debug;
 pub(crate) mod error;
+pub(crate) mod filter;
 
 use std::{
 	cmp,


### PR DESCRIPTION
Not done yet, just putting it up as a draft PR so I have somewhere external to track progress and link to.

## TODO

### `/messages`

 - [x] rooms/not_rooms filtering
 - [x] `filter.limit`
 - [x] per-event filtering
   - [x] `contains_url`
   - [x] senders/not_senders
   - [x] types/not_types
 - [ ] total limit on events examined to avoid a DoS by filtering for a non-existent event type

### `/sync`

 - [ ] do something about the broken sync cache (it's serving cached responses even when the filter parameters have changed)
 - [x] top-level room filtering
 - [x] timeline room filtering
 - [x] state room filtering
   - [ ] get confirmation that filter.room.state does not apply to invite_state [question in `#matrix-spec` about this][1]
 - [x] skip left/invited rooms with no updates
 - [x] ephemeral room filtering
 - [x] timeline per-event filtering
 - [ ] state per-event filtering
 - [ ] ephemeral per-event filtering
 - [ ] `limit`
 - [ ] `include_leave`
 - [ ] presence per-event filtering
 - [ ] global account_data filtering
 - [ ] room account_data filtering (unsure if this is a thing?)
 - [ ] double-check that interaction with lazy-loading is correct
 - [ ] double-check that notification/unread counts are okay
 - [ ] double-check that `state` filter applies to the `state` field in the response (delta between `since` and `prev_batch`), not to all state events (including the ones in `timeline`)

[1]: https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$twoEQAQ94z-oH3UCiQAQcO5JuuFyy9ein0BVO9OefFw?via=matrix.org&via=envs.net&via=element.io

### `/rooms/{roomId}/context/{eventId}`

Haven't looked at this one very closely yet

 - [ ] room filtering
 - [ ] per-event filtering

## Future work

I don't intend to do these bits as part of this PR.

Features:

 - Support for filtering on the sliding-sync endpoint. The API for this is totally different.
 - Support for the `event_fields` filter field.

Optimizations:

 - fast path in `WildcardAllowDenyList` for patterns that don't contain wildcards
 - fast path in `AllowDenyList` for allow-all and deny-all
 - `rooms <- rooms ∩ (timeline.rooms ∪ ephemeral.rooms ∪ state.rooms)` (would reduce work in cases where a room is individually filtered out of `timeline`, `ephemeral`, and `state)