### PR TITLE
Media security enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "ruma-identifiers-validation",
  "rusqlite",
  "rust-rocksdb",
+ "sanitize-filename",
  "sd-notify",
  "sentry",
  "sentry-tower",
@@ -3052,6 +3053,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sanitize-filename"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed72fbaf78e6f2d41744923916966c4fbe3d7c74e3037a8ee482f1115572603"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "image",
+ "infer",
  "ipaddress",
  "itertools",
  "jsonwebtoken",
@@ -1604,6 +1605,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
+
+[[package]]
+name = "infer"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865e8a58ae8e24d2c4412c31344afa1d302a3740ad67528c10f50d6876cdcf55"
 
 [[package]]
 name = "inlinable_string"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ rust-version = "1.77.0"
 [dependencies]
 console-subscriber = { version = "0.2", optional = true }
 
+infer = { version = "0.3", default-features = false }
+
 # for hot lib reload
 hot-lib-reloader = { version = "^0.7", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ url = { version = "2.5.0", features = ["serde"] }
 async-trait = "0.1.80"
 
 lru-cache = "0.1.2"
+sanitize-filename = "0.5.0"
 
 # standard date and time tools
 [dependencies.chrono]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ features = [
     "add-extension",
     "cors",
     "sensitive-headers",
+    "set-header",
     "trace",
     "util",
     "catch-panic",

--- a/src/api/client_server/media.rs
+++ b/src/api/client_server/media.rs
@@ -1,6 +1,7 @@
 use std::{io::Cursor, sync::Arc, time::Duration};
 
 use image::io::Reader as ImgReader;
+use infer::MatcherType;
 use ipaddress::IPAddress;
 use reqwest::Url;
 use ruma::api::client::{
@@ -178,11 +179,13 @@ pub(crate) async fn get_content_route(body: Ruma<get_content::v3::Request>) -> R
 		..
 	}) = services().media.get(mxc.clone()).await?
 	{
+		let content_disposition = Some(String::from(content_disposition_type(&file, &content_type)));
+
 		// TODO: safely sanitise filename to be included in the content-disposition
 		Ok(get_content::v3::Response {
 			file,
 			content_type,
-			content_disposition: Some("attachment".to_owned()),
+			content_disposition,
 			cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.to_owned()),
 			cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
 		})
@@ -241,10 +244,12 @@ pub(crate) async fn get_content_as_filename_route(
 		..
 	}) = services().media.get(mxc.clone()).await?
 	{
+		let content_disposition = Some(String::from(content_disposition_type(&file, &content_type)));
+
 		Ok(get_content_as_filename::v3::Response {
 			file,
 			content_type,
-			content_disposition: Some("attachment".to_owned()),
+			content_disposition,
 			cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.to_owned()),
 			cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
 		})
@@ -258,13 +263,20 @@ pub(crate) async fn get_content_as_filename_route(
 		)
 		.await
 		{
-			Ok(remote_content_response) => Ok(get_content_as_filename::v3::Response {
-				content_disposition: Some("attachment".to_owned()),
-				content_type: remote_content_response.content_type,
-				file: remote_content_response.file,
-				cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.to_owned()),
-				cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
-			}),
+			Ok(remote_content_response) => {
+				let content_disposition = Some(String::from(content_disposition_type(
+					&remote_content_response.file,
+					&remote_content_response.content_type,
+				)));
+
+				Ok(get_content_as_filename::v3::Response {
+					content_disposition,
+					content_type: remote_content_response.content_type,
+					file: remote_content_response.file,
+					cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.to_owned()),
+					cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
+				})
+			},
 			Err(e) => {
 				debug_warn!("Fetching media `{}` failed: {:?}", mxc, e);
 				Err(Error::BadRequest(ErrorKind::NotFound, "Remote media error."))
@@ -323,12 +335,14 @@ pub(crate) async fn get_content_thumbnail_route(
 		)
 		.await?
 	{
+		let content_disposition = Some(String::from(content_disposition_type(&file, &content_type)));
+
 		Ok(get_content_thumbnail::v3::Response {
 			file,
 			content_type,
 			cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.to_owned()),
 			cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
-			content_disposition: Some("attachment".to_owned()),
+			content_disposition,
 		})
 	} else if !server_is_ours(&body.server_name) && body.allow_remote {
 		if services()
@@ -373,12 +387,17 @@ pub(crate) async fn get_content_thumbnail_route(
 					)
 					.await?;
 
+				let content_disposition = Some(String::from(content_disposition_type(
+					&get_thumbnail_response.file,
+					&get_thumbnail_response.content_type,
+				)));
+
 				Ok(get_content_thumbnail::v3::Response {
 					file: get_thumbnail_response.file,
 					content_type: get_thumbnail_response.content_type,
 					cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.to_owned()),
 					cache_control: Some(CACHE_CONTROL_IMMUTABLE.to_owned()),
-					content_disposition: Some("attachment".to_owned()),
+					content_disposition,
 				})
 			},
 			Err(e) => {
@@ -687,4 +706,25 @@ fn url_preview_allowed(url_str: &str) -> bool {
 	}
 
 	false
+}
+
+/// Returns a Content-Disposition of `attachment` or `inline`, depending on the
+/// *parsed* contents of the file uploaded via format magic keys using `infer`
+/// crate (basically libmagic without needing libmagic).
+///
+/// This forbids trusting what the client or remote server says the file is from
+/// their `Content-Type` and we try to detect it ourselves. Also returns
+/// `attachment` if the Content-Type does not match what we detected.
+///
+/// TODO: add a "strict" function for comparing the Content-Type with what we
+/// detected: `file_type.mime_type() != content_type`
+fn content_disposition_type(buf: &[u8], _content_type: &Option<String>) -> &'static str {
+	let Some(file_type) = infer::get(buf) else {
+		return "attachment";
+	};
+
+	match file_type.matcher_type() {
+		MatcherType::IMAGE | MatcherType::AUDIO | MatcherType::TEXT | MatcherType::VIDEO => "inline",
+		_ => "attachment",
+	}
 }

--- a/src/api/client_server/media.rs
+++ b/src/api/client_server/media.rs
@@ -25,7 +25,7 @@ use crate::{
 const MXC_LENGTH: usize = 32;
 
 /// Cache control for immutable objects
-const CACHE_CONTROL_IMMUTABLE: &str = "public, max-age=31536000, immutable";
+const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
 
 const CORP_CROSS_ORIGIN: &str = "cross-origin";
 

--- a/src/utils/content_disposition.rs
+++ b/src/utils/content_disposition.rs
@@ -1,0 +1,88 @@
+use infer::MatcherType;
+
+/// Returns a Content-Disposition of `attachment` or `inline`, depending on the
+/// *parsed* contents of the file uploaded via format magic keys using `infer`
+/// crate (basically libmagic without needing libmagic).
+///
+/// This forbids trusting what the client or remote server says the file is from
+/// their `Content-Type` and we try to detect it ourselves. Also returns
+/// `attachment` if the Content-Type does not match what we detected.
+///
+/// TODO: add a "strict" function for comparing the Content-Type with what we
+/// detected: `file_type.mime_type() != content_type`
+pub(crate) fn content_disposition_type(buf: &[u8], _content_type: &Option<String>) -> &'static str {
+	let Some(file_type) = infer::get(buf) else {
+		return "attachment";
+	};
+
+	match file_type.matcher_type() {
+		MatcherType::IMAGE | MatcherType::AUDIO | MatcherType::TEXT | MatcherType::VIDEO => "inline",
+		_ => "attachment",
+	}
+}
+
+/// sanitises the file name for the Content-Disposition using
+/// `sanitize_filename` crate
+#[tracing::instrument]
+pub(crate) fn sanitise_filename(filename: String) -> String {
+	let options = sanitize_filename::Options {
+		truncate: false,
+		..Default::default()
+	};
+
+	sanitize_filename::sanitize_with_options(filename, options)
+}
+
+/// creates the final Content-Disposition based on whether the filename exists
+/// or not.
+///
+/// if filename exists: `Content-Disposition: attachment/inline;
+/// filename=filename.ext` else: `Content-Disposition: attachment/inline`
+#[tracing::instrument(skip(file))]
+pub(crate) fn make_content_disposition(
+	file: &[u8], content_type: &Option<String>, content_disposition: Option<String>,
+) -> String {
+	let filename = content_disposition.map_or_else(String::new, |content_disposition| {
+		let (_, filename) = content_disposition
+			.split_once("filename=")
+			.unwrap_or(("", ""));
+
+		if filename.is_empty() {
+			String::new()
+		} else {
+			sanitise_filename(filename.to_owned())
+		}
+	});
+
+	if !filename.is_empty() {
+		// Content-Disposition: attachment/inline; filename=filename.ext
+		format!("{}; filename={}", content_disposition_type(file, content_type), filename)
+	} else {
+		// Content-Disposition: attachment/inline
+		String::from(content_disposition_type(file, content_type))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn string_sanitisation() {
+		const SAMPLE: &str =
+			"🏳️‍⚧️this\\r\\n įs \r\\n ä \\r\nstrïng 🥴that\n\r ../../../../../../../may be\r\n malicious🏳️‍⚧️";
+		const SANITISED: &str = "🏳️‍⚧️thisrn įs n ä rstrïng 🥴that ..............may be malicious🏳️‍⚧️";
+
+		let options = sanitize_filename::Options {
+			windows: true,
+			truncate: true,
+			replacement: "",
+		};
+
+		// cargo test -- --nocapture
+		println!("{}", SAMPLE);
+		println!("{}", sanitize_filename::sanitize_with_options(SAMPLE, options.clone()));
+		println!("{:?}", SAMPLE);
+		println!("{:?}", sanitize_filename::sanitize_with_options(SAMPLE, options.clone()));
+
+		assert_eq!(SANITISED, sanitize_filename::sanitize_with_options(SAMPLE, options.clone()));
+	}
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod clap;
+pub(crate) mod content_disposition;
 pub(crate) mod debug;
 pub(crate) mod error;
 pub(crate) mod server_name;


### PR DESCRIPTION
These are follow up security enhancements from the previous security release.

Adds various recommended security response HTTP headers if not present already, including a strong Content-Security-Policy, as recommended by [spec](https://spec.matrix.org/v1.10/client-server-api/#security-considerations-4) and every websec guide out there. This has no affect on clients as it's only affecting the content being loaded, not what's loading the content. Malicious inline content has substantially less risk now. All of Matrix is just a bunch of JSON anyways so we shouldn't allow things like JavaScript execution/loading or frame ancestors anywhere.

Attempt to identify the Content-Type / MIME type from the file being uploaded via the file contents magic signatures and return `inline` Content-Disposition on only media content types like images, videos, audio, and text files (not documents). This prevents trusting what the client/remote server says the Content-Type is. The fallback will always be `attachment`.

And performs additional sanitisation on the file name for inclusion in the `Content-Disposition`. URL-safe encoding was already being done, but this is an additional precaution to catch any more edgecases.