### PR TITLE
Admin command to force set/download room state from another server

### DIFF
--- a/src/api/client/membership.rs
+++ b/src/api/client/membership.rs
@@ -1302,7 +1302,7 @@ async fn make_join_request(
 	make_join_response_and_server
 }
 
-async fn validate_and_add_event_id(
+pub async fn validate_and_add_event_id(
 	pdu: &RawJsonValue, room_version: &RoomVersionId, pub_key_map: &RwLock<BTreeMap<String, BTreeMap<String, Base64>>>,
 ) -> Result<(OwnedEventId, CanonicalJsonObject)> {
 	let mut value: CanonicalJsonObject = serde_json::from_str(pdu.get()).map_err(|e| {

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -47,7 +47,7 @@ pub(super) use filter::*;
 pub(super) use keys::*;
 pub(super) use media::*;
 pub(super) use membership::*;
-pub use membership::{join_room_by_id_helper, leave_all_rooms, leave_room};
+pub use membership::{join_room_by_id_helper, leave_all_rooms, leave_room, validate_and_add_event_id};
 pub(super) use message::*;
 pub(super) use presence::*;
 pub(super) use profile::*;


### PR DESCRIPTION
This is an implementation of Dendrite's admin API endpoint for downloading the room state from another server and replaces our room state with the remote server's ("download state"): https://github.com/matrix-org/dendrite/blob/46902e5766cc8efcc4f1abb38789f8179893c17d/roomserver/internal/perform/perform_admin.go#L225

One of the many reasons users want room deletion is to simply fix broken rooms because our copy is broken / "split brained" / etc. This admin debug command is not a replacement or substitute for that, however this is the first of many "room recovery" tools conduwuit has that upstream does not have.

If you know your room's state is split/broken and you know a trusted server in the room with the correct room state, this admin command can be used to get the room state from them.

I have used this to fix a split-state room I'm in where banned users were not showing up as so in the `m.room.member` event (my server thinks they're still in the room).

<img width="775" alt="image" src="https://github.com/girlbossceo/conduwuit/assets/112147643/b64597e6-da97-418b-8f5b-da7ab1dcd6bc">
