### PR TITLE
fix jemalloc linking in CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-use flake
+use flake ".#${DIRENV_DEVSHELL:-default}"
 
 PATH_add bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ env:
     # Use the all-features devshell instead of default, to ensure that features
     # match between nix and cargo
     DIRENV_DEVSHELL: all-features
+    # Get error output from nix that we can actually use
+    NIX_CONFIG: show-trace = true
 
 permissions:
     packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ env:
     # Custom nix binary cache if fork is being used
     ATTIC_ENDPOINT: ${{ vars.ATTIC_ENDPOINT }}
     ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
+    # Use the all-features devshell instead of default, to ensure that features
+    # match between nix and cargo
+    DIRENV_DEVSHELL: all-features
 
 permissions:
     packages: write
@@ -92,7 +95,7 @@ jobs:
                   echo 'source $HOME/.nix-profile/share/nix-direnv/direnvrc' > "$HOME/.direnvrc"
                   nix profile install --impure --inputs-from . nixpkgs#direnv nixpkgs#nix-direnv
                   direnv allow
-                  nix develop --command true
+                  nix develop .#all-features --command true
 
             - name: Run CI tests
               run: |
@@ -202,7 +205,7 @@ jobs:
                   echo 'source $HOME/.nix-profile/share/nix-direnv/direnvrc' > "$HOME/.direnvrc"
                   nix profile install --impure --inputs-from . nixpkgs#direnv nixpkgs#nix-direnv
                   direnv allow
-                  nix develop --command true
+                  nix develop .#all-features --command true
 
             - name: Build static ${{ matrix.target }}
               run: |

--- a/bin/complement
+++ b/bin/complement
@@ -21,7 +21,7 @@ toplevel="$(git rev-parse --show-toplevel)"
 
 pushd "$toplevel" > /dev/null
 
-bin/nix-build-and-cache just .#complement
+bin/nix-build-and-cache just .#static-complement
 
 docker load < result
 popd > /dev/null

--- a/bin/nix-build-and-cache
+++ b/bin/nix-build-and-cache
@@ -70,7 +70,7 @@ ci() {
         --inputs-from "$toplevel"
 
         # Keep sorted
-        "$toplevel#devShells.x86_64-linux.default"
+        "$toplevel#devShells.x86_64-linux.all-features"
         attic#default
         nixpkgs#direnv
         nixpkgs#jq

--- a/flake.nix
+++ b/flake.nix
@@ -184,8 +184,8 @@
             # Needed for building with io_uring
             pkgsHost.liburing
         ] else [])
-        ++
-        scopeHost.main.nativeBuildInputs;
+        ++ scopeHost.main.propagatedBuildInputs
+        ++ scopeHost.main.nativeBuildInputs;
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
     inputs.flake-utils.lib.eachDefaultSystem (system:
     let
       pkgsHost = inputs.nixpkgs.legacyPackages.${system};
+      pkgsHostStatic = pkgsHost.pkgsStatic;
 
       # The Rust toolchain to use
       toolchain = inputs.fenix.packages.${system}.fromToolchainFile {
@@ -43,6 +44,7 @@
       });
 
       scopeHost = mkScope pkgsHost;
+      scopeHostStatic = mkScope pkgsHostStatic;
 
       mkDevShell = scope: scope.pkgs.mkShell {
         env = scope.main.env // {
@@ -185,6 +187,6 @@
           )
         );
 
-      devShells.default = mkDevShell scopeHost;
+      devShells.default = mkDevShell scopeHostStatic;
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -198,5 +198,6 @@
         (scopeHostStatic.overrideScope (final: prev: {
           main = prev.main.override { default_features = false; };
         }));
+      devShells.dynamic = mkDevShell scopeHost;
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,10 @@
           # Convenient way to access a pinned version of Complement's source
           # code.
           COMPLEMENT_SRC = inputs.complement.outPath;
+
+          # Needed for Complement
+          CGO_CFLAGS = "-I${scope.pkgs.olm}/include";
+          CGO_LDFLAGS = "-L${scope.pkgs.olm}/lib";
         };
 
         # Development tools
@@ -77,7 +81,6 @@
 
           # Needed for Complement
           go
-          olm
 
           # Needed for our script for Complement
           jq

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,7 @@
         book = scopeHost.book;
 
         complement = scopeHost.complement;
+        static-complement = scopeHostStatic.complement;
       }
       //
       builtins.listToAttrs

--- a/flake.nix
+++ b/flake.nix
@@ -192,5 +192,9 @@
         (scopeHostStatic.overrideScope (final: prev: {
           main = prev.main.override { all_features = true; };
         }));
+      devShells.no-features = mkDevShell
+        (scopeHostStatic.overrideScope (final: prev: {
+          main = prev.main.override { default_features = false; };
+        }));
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -188,5 +188,9 @@
         );
 
       devShells.default = mkDevShell scopeHostStatic;
+      devShells.all-features = mkDevShell
+        (scopeHostStatic.overrideScope (final: prev: {
+          main = prev.main.override { all_features = true; };
+        }));
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -180,10 +180,6 @@
           # Useful for editing the book locally
           mdbook
         ])
-        ++ (if !pkgsHost.stdenv.isDarwin then [
-            # Needed for building with io_uring
-            pkgsHost.liburing
-        ] else [])
         ++ scopeHost.main.propagatedBuildInputs
         ++ scopeHost.main.nativeBuildInputs;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,8 @@
         ])
         ++ scope.main.propagatedBuildInputs
         ++ scope.main.nativeBuildInputs;
+
+        meta.broken = scope.main.meta.broken;
       };
     in
     {

--- a/nix/pkgs/main/default.nix
+++ b/nix/pkgs/main/default.nix
@@ -155,4 +155,11 @@ craneLib.buildPackage ( commonAttrs // {
   };
 
   meta.mainProgram = commonAttrs.pname;
+  # Dynamically-linked jemalloc is broken on linux due to link-order problems,
+  # where the symbols are being resolved to libc malloc/free before jemalloc is
+  # loaded. This problem does not occur on darwin for unknown reasons.
+  meta.broken =
+    stdenv.isLinux &&
+    !stdenv.hostPlatform.isStatic &&
+    (featureEnabled "jemalloc");
 })

--- a/nix/pkgs/main/default.nix
+++ b/nix/pkgs/main/default.nix
@@ -59,7 +59,13 @@ buildDepsOnlyEnv =
   let
     rocksdb' = rocksdb.override {
       jemalloc = rust-jemalloc-sys';
-      enableJemalloc = featureEnabled "jemalloc";
+      # rocksdb fails to build with prefixed jemalloc, which is required on
+      # darwin due to [1]. In this case, fall back to building rocksdb with
+      # libc malloc. This should not cause conflicts, because all of the
+      # jemalloc symbols are prefixed.
+      #
+      # [1]: https://github.com/tikv/jemallocator/blob/ab0676d77e81268cd09b059260c75b38dbef2d51/jemalloc-sys/src/env.rs#L17
+      enableJemalloc = featureEnabled "jemalloc" && !stdenv.isDarwin;
     };
   in
   {

--- a/nix/pkgs/main/default.nix
+++ b/nix/pkgs/main/default.nix
@@ -57,7 +57,7 @@ rust-jemalloc-sys' = (rust-jemalloc-sys.override {
 
 buildDepsOnlyEnv =
   let
-    rocksdb' = rocksdb.override {
+    rocksdb' = (rocksdb.override {
       jemalloc = rust-jemalloc-sys';
       # rocksdb fails to build with prefixed jemalloc, which is required on
       # darwin due to [1]. In this case, fall back to building rocksdb with
@@ -66,7 +66,11 @@ buildDepsOnlyEnv =
       #
       # [1]: https://github.com/tikv/jemallocator/blob/ab0676d77e81268cd09b059260c75b38dbef2d51/jemalloc-sys/src/env.rs#L17
       enableJemalloc = featureEnabled "jemalloc" && !stdenv.isDarwin;
-    };
+    }).overrideAttrs (old: {
+      # TODO: static rocksdb fails to build on darwin
+      # build log at <https://girlboss.ceo/~strawberry/pb/JjGH>
+      meta.broken = stdenv.hostPlatform.isStatic && stdenv.isDarwin;
+    });
   in
   {
     CARGO_PROFILE = profile;


### PR DESCRIPTION
This should hopefully resolve the "invalid free" error in CI for #392, and may resolve the segfault in #346.

This makes the following changes:

 - only link one instance of jemalloc
 - perform default-features unification in nix instead of cargo (this is more general version of what [this](https://github.com/girlbossceo/conduwuit/pull/392/commits/e61c7d24b2bf4a1f00dee0a39d52dca69467132b#diff-b4b08231ad4154725ea223e7749071af5d05f5b2844f0ff1057164045dc48269R22) and [this](https://github.com/girlbossceo/conduwuit/pull/346/files#diff-b4b08231ad4154725ea223e7749071af5d05f5b2844f0ff1057164045dc48269R27) are doing)
 - use static linking in the devshell (and therefore for unit tests in CI)
 - run CI with an all-features devshell

This does _not_ fix the issue that dynamically-linked jemalloc builds will crash with "invalid free". This is caused by the link order, which causes glibc to be loaded before jemalloc. All of our released builds are static, and now devshells/CI are as well, so this is lower priority but I would still like to fix it.