### PR TITLE
Check if database symlink already exists

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,8 +25,10 @@ case "$1" in
     # and permissions for the config.
     mkdir -v -p "$CONDUWUIT_DATABASE_PATH"
 
-    # symlink the previous location for compatibility
-    ln -s -v "$CONDUWUIT_DATABASE_PATH" "/var/lib/matrix-conduit"
+    # symlink the previous location for compatibility if it does not exist yet.
+    if ! test -L "/var/lib/matrix-conduit" ; then
+        ln -s -v "$CONDUWUIT_DATABASE_PATH" "/var/lib/matrix-conduit"
+    fi
 
     chown -v conduwuit:conduwuit -R "$CONDUWUIT_DATABASE_PATH"
     chown -v conduwuit:conduwuit -R "$CONDUWUIT_CONFIG_PATH"


### PR DESCRIPTION
This check is needed because the binary fails to install completely, if symlink is already existing

**test -L $object** [object exists and is a symbolic link (same as -h)]

It is not recommended to use -h [Excerpt: True if file exists and is a symbolic link. This operator is retained for compatibility with previous versions of this program. Do not rely on its existence; use -L instead.]