### PR TITLE
admin: media: Force flag on past media removal

### DIFF
--- a/src/admin/media/media_commands.rs
+++ b/src/admin/media/media_commands.rs
@@ -164,10 +164,12 @@ pub(crate) async fn delete_list(body: Vec<&str>) -> Result<RoomMessageEventConte
 	))
 }
 
-pub(crate) async fn delete_past_remote_media(_body: Vec<&str>, duration: String) -> Result<RoomMessageEventContent> {
+pub(crate) async fn delete_past_remote_media(
+	_body: Vec<&str>, duration: String, force: bool,
+) -> Result<RoomMessageEventContent> {
 	let deleted_count = services()
 		.media
-		.delete_all_remote_media_at_after_time(duration)
+		.delete_all_remote_media_at_after_time(duration, force)
 		.await?;
 
 	Ok(RoomMessageEventContent::text_plain(format!(

--- a/src/admin/media/mod.rs
+++ b/src/admin/media/mod.rs
@@ -32,6 +32,9 @@ pub(crate) enum MediaCommand {
 		/// - The duration (at or after), e.g. "5m" to delete all media in the
 		///   past 5 minutes
 		duration: String,
+		/// Continues deleting remote media if an undeletable object is found
+		#[arg(short, long)]
+		force: bool,
 	},
 }
 
@@ -44,6 +47,7 @@ pub(crate) async fn process(command: MediaCommand, body: Vec<&str>) -> Result<Ro
 		MediaCommand::DeleteList => delete_list(body).await?,
 		MediaCommand::DeletePastRemoteMedia {
 			duration,
-		} => delete_past_remote_media(body, duration).await?,
+			force,
+		} => delete_past_remote_media(body, duration, force).await?,
 	})
 }


### PR DESCRIPTION
When enabled, if a file is deemed unremovable, it skips past it and continues deleting all other files that fit the criteria. Additionally, fix age comparison under the same command.