### PR TITLE
remove unused CONDUWUIT_CONFIG_FILE variable

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -6,7 +6,6 @@ set -e
 
 CONDUWUIT_DATABASE_PATH=/var/lib/conduwuit
 CONDUWUIT_CONFIG_PATH=/etc/conduwuit
-CONDUWUIT_CONFIG_FILE="${CONDUWUIT_CONFIG_PATH}/conduwuit.toml"
 
 case "$1" in
   configure)


### PR DESCRIPTION
Related: https://github.com/girlbossceo/conduwuit/issues/465

When getting this app deployed I was running into confusion about which environment variables were needed. During that process I noticed that this variable is not used in the postinst script, so I removed it to help reduce the confusion.

## Changes

- remove unused CONDUWUIT_CONFIG_FILE variable from debian postinst script