### PR TITLE
Improve configuration documentation

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -15,7 +15,7 @@ in `/etc/conduwuit/conduwuit.toml`.
 
 ### Running
 
-The package uses the [`conduwuit.service`](../configuration.md#example-systemd-unit-file) systemd unit file to start and stop conduwuit. The binary is installed at `/usr/sbin/conduwuit`.
+The package uses the [`conduwuit.service`](../configuration/examples.md#example-systemd-unit-file) systemd unit file to start and stop conduwuit. The binary is installed at `/usr/sbin/conduwuit`.
 
 This package assumes by default that conduwuit will be placed behind a reverse proxy. The default config options apply (listening on `localhost` and TCP port `6167`). Matrix federation requires a valid domain name and TLS, so you will need to set up TLS certificates and renewal for it to work properly if you intend to federate.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 - [Introduction](introduction.md)
 - [Differences from upstream Conduit](differences.md)
-- [Example configuration](configuration.md)
+- [Example configuration](configuration/examples.md)
 - [Deploying](deploying.md)
     - [Generic](deploying/generic.md)
     - [NixOS](deploying/nixos.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,8 @@
 
 - [Introduction](introduction.md)
 - [Differences from upstream Conduit](differences.md)
-- [Example configuration](configuration/examples.md)
+- [Configuration](configuration.md)
+    - [Examples](configuration/examples.md)
 - [Deploying](deploying.md)
     - [Generic](deploying/generic.md)
     - [NixOS](deploying/nixos.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,18 @@
+# Configuration
+
+This chapter describes various ways to configure conduwuit.
+
+## Basics
+
+Conduwuit uses a config file for the majority of the settings. Please refer to the
+[example config file](./configuration/examples.md#example-configuration) for all of those settings.
+The config file to use can either be specified on the command line when running conduwuit by specifying the
+`-c`, `--config` flag. Alternatively, you can use the environment variable `CONDUWUIT_CONFIG` to specify the config
+file to used.
+
+## Environment variables
+
+All of the settings that are found in the config file can be specified by using environment variables.
+The environment variable names should be all caps and prefixed with `CONDUWUIT_`.
+For example, if the setting you are changing is `max_request_size`, then the environment variable to set is
+`CONDUWUIT_MAX_REQUEST_SIZE`.

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -4,7 +4,7 @@
 <summary>Example configuration</summary>
 
 ```toml
-{{#include ../conduwuit-example.toml}}
+{{#include ../../conduwuit-example.toml}}
 ```
 
 </details>
@@ -15,7 +15,7 @@
 <summary>Debian systemd unit file</summary>
 
 ```
-{{#include ../debian/conduwuit.service}}
+{{#include ../../debian/conduwuit.service}}
 ```
 
 </details>
@@ -26,7 +26,7 @@
 <summary>Arch Linux systemd unit file</summary>
 
 ```
-{{#include ../arch/conduwuit.service}}
+{{#include ../../arch/conduwuit.service}}
 ```
 
 </details>

--- a/docs/deploying/docker.md
+++ b/docs/deploying/docker.md
@@ -44,7 +44,7 @@ docker run -d -p 8448:6167 \
 
 or you can use [docker compose](#docker-compose).
 
-The `-d` flag lets the container run in detached mode. You may supply an optional `conduwuit.toml` config file, the example config can be found [here](../configuration.md).
+The `-d` flag lets the container run in detached mode. You may supply an optional `conduwuit.toml` config file, the example config can be found [here](../configuration/examples.md).
 You can pass in different env vars to change config values on the fly. You can even configure conduwuit completely by using env vars. For an overview of possible
 values, please take a look at the [`docker-compose.yml`](docker-compose.yml) file.
 

--- a/docs/deploying/generic.md
+++ b/docs/deploying/generic.md
@@ -43,11 +43,11 @@ If conduwuit runs behind a router or in a container and has a different public I
 
 ## Setting up a systemd service
 
-The systemd unit for conduwuit can be found [here](../configuration.md#example-systemd-unit-file). You may need to change the `ExecStart=` path to where you placed the conduwuit binary.
+The systemd unit for conduwuit can be found [here](../configuration/examples.md#example-systemd-unit-file). You may need to change the `ExecStart=` path to where you placed the conduwuit binary.
 
 ## Creating the conduwuit configuration file
 
-Now we need to create the conduwuit's config file in `/etc/conduwuit/conduwuit.toml`. The example config can be found at [conduwuit-example.toml](../configuration.md).**Please take a moment to read it. You need to change at least the server name.**
+Now we need to create the conduwuit's config file in `/etc/conduwuit/conduwuit.toml`. The example config can be found at [conduwuit-example.toml](../configuration/examples.md).**Please take a moment to read it. You need to change at least the server name.**
 
 RocksDB is the only supported database backend. SQLite only exists for historical reasons, is not recommended, and will be removed soon (likely in v0.5.0). Any performance issues, storage issues, database issues, etc will not be assisted if using SQLite and you will be asked to migrate to RocksDB first.
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -28,7 +28,7 @@ Any commands with `-list` in them will require a codeblock in the message with e
 
 If using RocksDB, there's very little you need to do. Compaction is ran automatically based on various defined thresholds tuned for conduwuit to be high performance with the least I/O amplifcation or overhead. Manually running compaction is not recommended, or compaction via a timer. RocksDB is built with io_uring support via liburing for async read I/O.
 
-Some RocksDB settings can be adjusted such as the compression method chosen. See the RocksDB section in the [example config](configuration.md). btrfs users may benefit from disabling compression on RocksDB if CoW is in use.
+Some RocksDB settings can be adjusted such as the compression method chosen. See the RocksDB section in the [example config](configuration/examples.md). btrfs users may benefit from disabling compression on RocksDB if CoW is in use.
 
 RocksDB troubleshooting can be found [in the RocksDB section of troubleshooting](troubleshooting.md).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@
 
 #### Direct IO
 
-Some filesystems may not like RocksDB using [Direct IO](https://github.com/facebook/rocksdb/wiki/Direct-IO). Direct IO is for non-buffered I/O which improves conduwuit performance, but at least FUSE is a filesystem potentially known to not like this. See the [example config](configuration.md) for disabling it if needed. Issues from Direct IO on unsupported filesystems are usually shown as startup errors.
+Some filesystems may not like RocksDB using [Direct IO](https://github.com/facebook/rocksdb/wiki/Direct-IO). Direct IO is for non-buffered I/O which improves conduwuit performance, but at least FUSE is a filesystem potentially known to not like this. See the [example config](configuration/examples.md) for disabling it if needed. Issues from Direct IO on unsupported filesystems are usually shown as startup errors.
 
 #### Database corruption
 
@@ -32,7 +32,8 @@ By default, conduwuit uses `TolerateCorruptedTailRecords` as generally these may
 `AbsoluteConsistency` will fail to start the database if any sign of corruption is detected. `SkipAnyCorruptedRecord` will skip all forms of corruption unless it forbids the database from opening (e.g. too severe). Usage of `SkipAnyCorruptedRecord` voids any support as this may cause more damage and/or leave your database in a permanently inconsistent state, but it may do something if `PointInTime` does not work as a last ditch effort.
 
 With this in mind:
-- First start conduwuit with the `PointInTime` recovery method. See the [example config](configuration.md) for how to do this using `rocksdb_recovery_mode`
+
+- First start conduwuit with the `PointInTime` recovery method. See the [example config](configuration/examples.md) for how to do this using `rocksdb_recovery_mode`
 - If your database successfully opens, clients are recommended to clear their client cache to account for the rollback
 - Leave your conduwuit running in `PointInTime` for at least 30-60 minutes so as much possible corruption is restored
 - If all goes will, you should be able to restore back to using `TolerateCorruptedTailRecords` and you have successfully recovered your database

--- a/docs/turn.md
+++ b/docs/turn.md
@@ -13,7 +13,7 @@ realm=<your server domain>
 ```
 A common way to generate a suitable alphanumeric secret key is by using `pwgen -s 64 1`.
 
-These same values need to be set in conduwuit. See the [example config](configuration.md) in the TURN section for configuring these and restart conduwuit after.
+These same values need to be set in conduwuit. See the [example config](configuration/examples.md) in the TURN section for configuring these and restart conduwuit after.
 
 ### Run
 Run the [Coturn](https://hub.docker.com/r/coturn/coturn) image using


### PR DESCRIPTION
This adds a spot in the configuration chapter that explains how the app can be configured.
The goal here was to make it a bit more clear how the app can be configured.

When I was launching this app from a container I needed to look around to figure out how to specify the config file to use and found the `CONDUWUIT_CONFIG` variable listed in some other files which clued me into how the settings were being set.