### PR TITLE
 Bind Mount the old matrix-conduit directory

### DIFF
--- a/arch/conduwuit.service
+++ b/arch/conduwuit.service
@@ -45,6 +45,8 @@ RuntimeDirectory=conduwuit
 RuntimeDirectoryMode=0750
 
 Environment="CONDUWUIT_CONFIG=/etc/conduwuit/conduwuit.toml"
+BindPaths=/var/lib/private/conduwuit:/var/lib/matrix-conduit
+BindPaths=/var/lib/private/conduwuit:/var/lib/private/matrix-conduit
 
 ExecStart=/usr/bin/conduwuit
 Restart=on-failure


### PR DESCRIPTION
The previous migration may bring trouble if users ignore the post upgrade message and don’t change their database_path after upgrading. This bind mount property should make things better.