### PR TITLE
Don't send empty presence EDUs

### DIFF
--- a/src/service/sending/sender.rs
+++ b/src/service/sending/sender.rs
@@ -324,8 +324,10 @@ fn select_edus_presence(
 		}
 	}
 
-	let presence_content = Edu::Presence(PresenceContent::new(presence_updates));
-	events.push(serde_json::to_vec(&presence_content).expect("PresenceEvent can be serialized"));
+	if !presence_updates.is_empty() {
+		let presence_content = Edu::Presence(PresenceContent::new(presence_updates));
+		events.push(serde_json::to_vec(&presence_content).expect("PresenceEvent can be serialized"));
+	}
 
 	Ok(true)
 }


### PR DESCRIPTION
I run a homeserver whose logs show a high number of incoming empty presence EDUs originating from the user agent "Conduwuit/0.4.4". They arrive at a rate of about 2 queries per second per Conduwuit server.

The empty EDUs all look the same, only with `origin_server_ts` increasing:

```
{"origin":"example.com","origin_server_ts":1720266475601,"edus":[{"edu_type":"m.presence","content":{"push":[]}}]}
```

These updates are unnecessary because they don't do anything. They only increase network traffic and CPU usage on both sides.

After this commit, the empty presence updates are no longer inserted into the outgoing event queue.