### PR TITLE
Documentation: Introduce a new way of deploying conduwuit using caddy in Docker

### DIFF
--- a/docs/deploying/docker-compose.with-caddy.yml
+++ b/docs/deploying/docker-compose.with-caddy.yml
@@ -1,0 +1,54 @@
+services:
+    caddy:
+    # This compose file uses caddy-docker-proxy as the reverse proxy for conduwuit!
+    # For more info, visit https://github.com/lucaslorentz/caddy-docker-proxy
+        image: lucaslorentz/caddy-docker-proxy:ci-alpine
+        ports:
+            - 80:80
+            - 443:443
+        environment:
+            - CADDY_INGRESS_NETWORKS=caddy
+        networks:
+            - caddy
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./data:/data
+        restart: unless-stopped
+        labels:
+            caddy: example.com
+            caddy.0_respond: /.well-known/matrix/server {"m.server":"matrix.example.com:443"}
+            caddy.1_respond: /.well-known/matrix/client {"m.server":{"base_url":"https://matrix.example.com"},"m.homeserver":{"base_url":"https://matrix.example.com"},"org.matrix.msc3575.proxy":{"url":"https://matrix.example.com"}}
+
+    homeserver:
+        ### If you already built the conduwuit image with 'docker build' or want to use a registry image,
+        ### then you are ready to go.
+        image: girlbossceo/conduwuit:latest
+        restart: unless-stopped
+        volumes:
+            - db:/var/lib/conduwuit
+            #- ./conduwuit.toml:/etc/conduwuit.toml
+        environment:
+            CONDUWUIT_SERVER_NAME: example.com # EDIT THIS
+            CONDUWUIT_DATABASE_PATH: /var/lib/conduwuit
+            CONDUWUIT_DATABASE_BACKEND: rocksdb
+            CONDUWUIT_PORT: 6167
+            CONDUWUIT_MAX_REQUEST_SIZE: 20_000_000 # in bytes, ~20 MB
+            CONDUWUIT_ALLOW_REGISTRATION: 'true'
+            CONDUWUIT_ALLOW_FEDERATION: 'true'
+            CONDUWUIT_ALLOW_CHECK_FOR_UPDATES: 'true'
+            CONDUWUIT_TRUSTED_SERVERS: '["matrix.org"]'
+            #CONDUWUIT_LOG: warn,state_res=warn
+            CONDUWUIT_ADDRESS: 0.0.0.0
+            #CONDUWUIT_CONFIG: './conduwuit.toml' # Uncomment if you mapped config toml above
+        networks:
+            - caddy
+        labels:
+            caddy: matrix.example.com
+            caddy.reverse_proxy: "{{upstreams 6167}}"
+
+volumes:
+    db:
+
+networks:
+    caddy:
+        external: true

--- a/docs/deploying/docker.md
+++ b/docs/deploying/docker.md
@@ -59,12 +59,21 @@ If the `docker run` command is not for you or your setup, you can also use one o
 Depending on your proxy setup, you can use one of the following files;
 
 - If you already have a `traefik` instance set up, use [`docker-compose.for-traefik.yml`](docker-compose.for-traefik.yml)
-- If you don't have a `traefik` instance set up (or any other reverse proxy), use [`docker-compose.with-traefik.yml`](docker-compose.with-traefik.yml)
+- If you don't have a `traefik` instance set up and would like to use it, use [`docker-compose.with-traefik.yml`](docker-compose.with-traefik.yml)
+- If you want a setup that works out of the box with `caddy-docker-proxy`, use [`docker-compose.with-caddy.yml`](docker-compose.with-caddy.yml) and replace all `example.com` placeholders with your own domain
 - For any other reverse proxy, use [`docker-compose.yml`](docker-compose.yml)
 
 When picking the traefik-related compose file, rename it so it matches `docker-compose.yml`, and
 rename the override file to `docker-compose.override.yml`. Edit the latter with the values you want
 for your server.
+
+When picking the `caddy-docker-proxy` compose file, it's important to first create the `caddy` network before spinning up the containers:
+
+```bash
+docker network create caddy
+```
+
+After that, you can rename it so it matches `docker-compose.yml` and spin up the containers!
 
 Additional info about deploying conduwuit can be found [here](generic.md).
 


### PR DESCRIPTION
As discussed on Matrix, I've added a compose setup which uses `caddy-docker-proxy` as the reverse proxy. After replacing `example.com` with a real domain and pointing DNS A records to the correct IP, this setup should work out of the box.