### PR TITLE
fix media_startup_check typo

### DIFF
--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -401,7 +401,7 @@ allow_profile_lookup_federation_requests = true
 # setting this to false may reduce startup time.
 #
 # Enabled by default.
-#media_statup_check = true
+#media_startup_check = true
 
 # OpenID token expiration/TTL in seconds
 #

--- a/nix/pkgs/complement/config.toml
+++ b/nix/pkgs/complement/config.toml
@@ -14,7 +14,7 @@ yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse = true
 ip_range_denylist = []
 url_preview_domain_contains_allowlist = ["*"]
 media_compat_file_link = false
-media_statup_check = false
+media_startup_check = false
 rocksdb_direct_io = false
 
 [global.tls]


### PR DESCRIPTION
`migrations.rs` refers to `startup` instead of `statup`. ~~There is currently no warning if an invalid config variable is set, as far as I can tell.~~

https://github.com/girlbossceo/conduwuit/blob/06531993f69b8cefd5d67d3589791ca9cd6785c2/src/service/globals/migrations.rs#L130

Briefly tested with the `CONDUWUIT_MEDIA_STARTUP_CHECK=true` environment variable in the latest docker image, but not main or Complement. Can do so if necessary, but the change seems simple enough. I checked for other misspellings in `conduwuit-example.toml` and didn't find any, but I'm not familiar with the codebase, yet, so I may have missed others.