### PR TITLE
ci: typo, steps name is Sync repository

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Sync repository
-              uses: https://github.com/https://github.com/actions/checkout@v4
+              uses: https://github.com/actions/checkout@v4
 
             - name: Tag comparison check
               if: startsWith(gitea.ref, 'refs/tags/v')


### PR DESCRIPTION
ci: typo, steps name is Sync repository 

format {org}/{repo}[/path]@ref. Actual 'https://github.com/https://github.com/actions/checkout@v4' 

-----------------------------------------------------------------------------

- [x] I ran `cargo fmt` ,  `cargo clippy`, `ci.yaml`, and `cargo test`
- [x] I agree to release my code and all other changes of this MR under the Apache-2.0 license