### PR TITLE
Add config note for systems that pass on journal to rsyslog

### DIFF
--- a/docs/deploying/generic.md
+++ b/docs/deploying/generic.md
@@ -58,6 +58,8 @@ The systemd unit for conduwuit can be found
 [here](../configuration/examples.md#example-systemd-unit-file). You may need to
 change the `ExecStart=` path to where you placed the conduwuit binary.
 
+On systems where rsyslog is used alongside journald (i.e. Red Hat-based distros and OpenSUSE), put `$EscapeControlCharactersOnReceive off` inside `/etc/rsyslog.conf` to allow color in logs.
+
 ## Creating the conduwuit configuration file
 
 Now we need to create the conduwuit's config file in


### PR DESCRIPTION
journald itself (when viewed through journalctl) omits conduwuit’s ANSI escape code, but rsyslog displays either colour or `#033` strings:

https://www.rsyslog.com/doc/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.html

https://access.redhat.com/solutions/1484553