### PR TITLE
add support for binding to a specific interface for url previews

### DIFF
--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -1117,6 +1117,16 @@
 #
 #ip_range_denylist = ["127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
 
+# Optional interface to bind to with SO_BINDTODEVICE for URL previews.
+# If not set, it will not bind to a specific interface.
+# This uses [`reqwest::ClientBuilder::interface`] under the hood.
+#
+# To list the interfaces on your system, use the command `ip link show`
+#
+# Example: `"eth0"`
+#
+#url_preview_bound_interface =
+
 # Vector list of domains allowed to send requests to for URL previews.
 # Defaults to none. Note: this is a *contains* match, not an explicit
 # match. Putting "google.com" will match "https://google.com" and

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1250,6 +1250,16 @@ pub struct Config {
 	#[serde(default = "default_ip_range_denylist")]
 	pub ip_range_denylist: Vec<String>,
 
+	/// Optional interface to bind to with SO_BINDTODEVICE for URL previews.
+	/// If not set, it will not bind to a specific interface.
+	/// This uses [`reqwest::ClientBuilder::interface`] under the hood.
+	///
+	/// To list the interfaces on your system, use the command `ip link show`
+	///
+	/// Example: `"eth0"`
+	#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+	pub url_preview_bound_interface: Option<String>,
+
 	/// Vector list of domains allowed to send requests to for URL previews.
 	/// Defaults to none. Note: this is a *contains* match, not an explicit
 	/// match. Putting "google.com" will match "https://google.com" and
@@ -1960,6 +1970,15 @@ impl fmt::Display for Config {
 		line("Forbidden room aliases", {
 			&self.forbidden_alias_names.patterns().iter().join(", ")
 		});
+		#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+		line(
+			"URL preview bound interface",
+			if let Some(interface) = &self.url_preview_bound_interface {
+				interface
+			} else {
+				"not set"
+			},
+		);
 		line(
 			"URL preview domain contains allowlist",
 			&self.url_preview_domain_contains_allowlist.join(", "),


### PR DESCRIPTION
This is helpful to, for example, bind to an interface that can only access the public internet. The resulting setup is less maintenance-heavy / error-prone than manually maintaining a deny/allowlist to protect internal resources.

In my setup, I'm using podman's `macvlan` driver to provide direct access to my host's `eno1` interface, which accesses the public net, like so:

```unit
[Network]
DisableDNS=false
IPv6=true
Subnet=10.89.1.0/24
Gateway=10.89.1.1
Driver=macvlan
Options=parent=eno1
```

This means that the URL preview requests can't access any of my local services or my private network.