### PR TITLE
fix github actions runs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,6 +752,7 @@ jobs:
 
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
             GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+            GHCR_ENABLED: "${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'true' || 'false' }}"
         steps:
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
@@ -793,8 +794,10 @@ jobs:
                     docker tag $(docker images -q conduwuit:main) ${DOCKER_AMD64}
                     docker push ${DOCKER_AMD64}
                   fi
-                  docker tag $(docker images -q conduwuit:main) ${GHCR_AMD64}
-                  docker push ${GHCR_AMD64}
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GHCR_AMD64}
+                    docker push ${GHCR_AMD64}
+                  fi
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker tag $(docker images -q conduwuit:main) ${GLCR_AMD64}
                     docker push ${GLCR_AMD64}
@@ -807,8 +810,10 @@ jobs:
                     docker tag $(docker images -q conduwuit:main) ${DOCKER_ARM64}
                     docker push ${DOCKER_ARM64}
                   fi
-                  docker tag $(docker images -q conduwuit:main) ${GHCR_ARM64}
-                  docker push ${GHCR_ARM64}
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GHCR_ARM64}
+                    docker push ${GHCR_ARM64}
+                  fi
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker tag $(docker images -q conduwuit:main) ${GLCR_ARM64}
                     docker push ${GLCR_ARM64}
@@ -821,8 +826,10 @@ jobs:
                     docker tag $(docker images -q conduwuit:main) ${DOCKER_AMD64}-debug
                     docker push ${DOCKER_AMD64}-debug
                   fi
-                  docker tag $(docker images -q conduwuit:main) ${GHCR_AMD64}-debug
-                  docker push ${GHCR_AMD64}-debug
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GHCR_AMD64}-debug
+                    docker push ${GHCR_AMD64}-debug
+                  fi
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker tag $(docker images -q conduwuit:main) ${GLCR_AMD64}-debug
                     docker push ${GLCR_AMD64}-debug
@@ -835,8 +842,10 @@ jobs:
                     docker tag $(docker images -q conduwuit:main) ${DOCKER_ARM64}-debug
                     docker push ${DOCKER_ARM64}-debug
                   fi
-                  docker tag $(docker images -q conduwuit:main) ${GHCR_ARM64}-debug
-                  docker push ${GHCR_ARM64}-debug
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GHCR_ARM64}-debug
+                    docker push ${GHCR_ARM64}-debug
+                  fi
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker tag $(docker images -q conduwuit:main) ${GLCR_ARM64}-debug
                     docker push ${GLCR_ARM64}-debug
@@ -850,8 +859,10 @@ jobs:
                     docker manifest create ${DOCKER_BRANCH} --amend ${DOCKER_ARM64} --amend ${DOCKER_AMD64}
                   fi
                   # GitHub Container Registry
-                  docker manifest create ${GHCR_TAG} --amend ${GHCR_ARM64} --amend ${GHCR_AMD64}
-                  docker manifest create ${GHCR_BRANCH} --amend ${GHCR_ARM64} --amend ${GHCR_AMD64}
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker manifest create ${GHCR_TAG} --amend ${GHCR_ARM64} --amend ${GHCR_AMD64}
+                    docker manifest create ${GHCR_BRANCH} --amend ${GHCR_ARM64} --amend ${GHCR_AMD64}
+                  fi
                   # GitLab Container Registry
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker manifest create ${GLCR_TAG} --amend ${GLCR_ARM64} --amend ${GLCR_AMD64}
@@ -866,8 +877,10 @@ jobs:
                     docker manifest create ${DOCKER_BRANCH}-debug --amend ${DOCKER_ARM64}-debug --amend ${DOCKER_AMD64}-debug
                   fi
                   # GitHub Container Registry
-                  docker manifest create ${GHCR_TAG}-debug --amend ${GHCR_ARM64}-debug --amend ${GHCR_AMD64}-debug
-                  docker manifest create ${GHCR_BRANCH}-debug --amend ${GHCR_ARM64}-debug --amend ${GHCR_AMD64}-debug
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker manifest create ${GHCR_TAG}-debug --amend ${GHCR_ARM64}-debug --amend ${GHCR_AMD64}-debug
+                    docker manifest create ${GHCR_BRANCH}-debug --amend ${GHCR_ARM64}-debug --amend ${GHCR_AMD64}-debug
+                  fi
                   # GitLab Container Registry
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker manifest create ${GLCR_TAG}-debug --amend ${GLCR_ARM64}-debug --amend ${GLCR_AMD64}-debug
@@ -882,10 +895,12 @@ jobs:
                     docker manifest push ${DOCKER_TAG}-debug
                     docker manifest push ${DOCKER_BRANCH}-debug
                   fi
-                  docker manifest push ${GHCR_TAG}
-                  docker manifest push ${GHCR_BRANCH}
-                  docker manifest push ${GHCR_TAG}-debug
-                  docker manifest push ${GHCR_BRANCH}-debug
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    docker manifest push ${GHCR_TAG}
+                    docker manifest push ${GHCR_BRANCH}
+                    docker manifest push ${GHCR_TAG}-debug
+                    docker manifest push ${GHCR_BRANCH}-debug
+                  fi
                   if [ ! -z $GITLAB_TOKEN ]; then
                     docker manifest push ${GLCR_TAG}
                     docker manifest push ${GLCR_BRANCH}
@@ -899,8 +914,10 @@ jobs:
                     echo "- \`docker pull ${DOCKER_TAG}\`" >> $GITHUB_STEP_SUMMARY
                     echo "- \`docker pull ${DOCKER_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
                   fi
-                  echo "- \`docker pull ${GHCR_TAG}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- \`docker pull ${GHCR_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
+                  if [ $GHCR_ENABLED = "true" ]; then
+                    echo "- \`docker pull ${GHCR_TAG}\`" >> $GITHUB_STEP_SUMMARY
+                    echo "- \`docker pull ${GHCR_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
+                  fi
                   if [ ! -z $GITLAB_TOKEN ]; then
                     echo "- \`docker pull ${GLCR_TAG}\`" >> $GITHUB_STEP_SUMMARY
                     echo "- \`docker pull ${GLCR_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Setup SSH web publish
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              env:
+                web_upload_ssh_private_key: ${{ secrets.WEB_UPLOAD_SSH_PRIVATE_KEY }}
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   mkdir -p -v ~/.ssh
 
@@ -184,7 +186,7 @@ jobs:
 
             # use sccache for Rust
             - name: Run sccache-cache
-              if: (github.event.pull_request.draft != true) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && (vars.SCCACHE_ENDPOINT != '') && (github.event.pull_request.user.login != 'renovate[bot]')
+              if: (env.SCCACHE_GHA_ENABLED == 'true')
               uses: mozilla-actions/sccache-action@main
               with:
                 version: "v0.8.2"
@@ -281,7 +283,9 @@ jobs:
                 persist-credentials: false
 
             - name: Setup SSH web publish
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              env:
+                web_upload_ssh_private_key: ${{ secrets.WEB_UPLOAD_SSH_PRIVATE_KEY }}
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   mkdir -p -v ~/.ssh
 
@@ -360,7 +364,7 @@ jobs:
 
             # use sccache for Rust
             - name: Run sccache-cache
-              if: (github.event.pull_request.draft != true) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && (vars.SCCACHE_ENDPOINT != '') && (github.event.pull_request.user.login != 'renovate[bot]')
+              if: (env.SCCACHE_GHA_ENABLED == 'true')
               uses: mozilla-actions/sccache-action@main
               with:
                 version: "v0.8.2"
@@ -492,7 +496,7 @@ jobs:
                   fi
 
             - name: Upload static-${{ matrix.target }}-all-features to webserver
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   if [ ! -z $WEB_UPLOAD_SSH_USERNAME ]; then
                     scp static-${{ matrix.target }} website:/var/www/girlboss.ceo/~strawberry/conduwuit/ci-bins/${GH_SHA}/static-${{ matrix.target }}
@@ -506,7 +510,7 @@ jobs:
                   fi
 
             - name: Upload static deb ${{ matrix.target }}-all-features to webserver
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   if [ ! -z $WEB_UPLOAD_SSH_USERNAME ]; then
                     scp ${{ matrix.target }}.deb website:/var/www/girlboss.ceo/~strawberry/conduwuit/ci-bins/${GH_SHA}/${{ matrix.target }}.deb
@@ -528,14 +532,14 @@ jobs:
                   compression-level: 0
 
             - name: Upload static-${{ matrix.target }}-debug-all-features to webserver
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   if [ ! -z $WEB_UPLOAD_SSH_USERNAME ]; then
                     scp static-${{ matrix.target }}-debug website:/var/www/girlboss.ceo/~strawberry/conduwuit/ci-bins/${GH_SHA}/static-${{ matrix.target }}-debug
                   fi
 
             - name: Upload static deb ${{ matrix.target }}-debug-all-features to webserver
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   if [ ! -z $WEB_UPLOAD_SSH_USERNAME ]; then
                     scp ${{ matrix.target }}-debug.deb website:/var/www/girlboss.ceo/~strawberry/conduwuit/ci-bins/${GH_SHA}/${{ matrix.target }}-debug.deb
@@ -584,14 +588,14 @@ jobs:
                   fi
 
             - name: Upload OCI image ${{ matrix.target }}-all-features to webserver
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   if [ ! -z $WEB_UPLOAD_SSH_USERNAME ]; then
                     scp oci-image-${{ matrix.target }}.tar.gz website:/var/www/girlboss.ceo/~strawberry/conduwuit/ci-bins/${GH_SHA}/oci-image-${{ matrix.target }}.tar.gz
                   fi
 
             - name: Upload OCI image ${{ matrix.target }}-debug-all-features to webserver
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   if [ ! -z $WEB_UPLOAD_SSH_USERNAME ]; then
                     scp oci-image-${{ matrix.target }}-debug.tar.gz website:/var/www/girlboss.ceo/~strawberry/conduwuit/ci-bins/${GH_SHA}/oci-image-${{ matrix.target }}-debug.tar.gz
@@ -610,7 +614,9 @@ jobs:
                 persist-credentials: false
 
             - name: Setup SSH web publish
-              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+              env:
+                web_upload_ssh_private_key: ${{ secrets.WEB_UPLOAD_SSH_PRIVATE_KEY }}
+              if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (env.web_upload_ssh_private_key != '') && github.event.pull_request.user.login != 'renovate[bot]'
               run: |
                   mkdir -p -v ~/.ssh
 
@@ -647,7 +653,7 @@ jobs:
 
             # use sccache for Rust
             - name: Run sccache-cache
-              if: (github.event.pull_request.draft != true) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && (vars.SCCACHE_ENDPOINT != '') && (github.event.pull_request.user.login != 'renovate[bot]')
+              if: (env.SCCACHE_GHA_ENABLED == 'true')
               uses: mozilla-actions/sccache-action@main
 
             # use rust-cache
@@ -711,24 +717,35 @@ jobs:
                   name: conduwuit-macos-arm64
                   path: conduwuit-macos-arm64
                   if-no-files-found: error
-
+    variables: 
+      outputs:
+        github_repository: ${{ steps.var.outputs.github_repository }}
+      runs-on: "ubuntu-latest"
+      steps:
+        - name: Setting global variables
+          uses: actions/github-script@v7
+          id: var
+          with:
+            script: |
+              console.log('${{ github.repository }}'.toLowerCase())
+              core.setOutput('github_repository', '${{ github.repository }}'.toLowerCase())
     docker:
         name: Docker publish
         runs-on: ubuntu-24.04
-        needs: build
+        needs: [build, variables]
         permissions:
           packages: write
           contents: read
-        if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && (vars.DOCKER_USERNAME != '') && (vars.GITLAB_USERNAME != '') && github.event.pull_request.user.login != 'renovate[bot]'
+        if: (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || (github.event.pull_request.draft != true)) && github.event.pull_request.user.login != 'renovate[bot]'
         env:
-            DOCKER_ARM64: docker.io/${{ github.repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-arm64v8
-            DOCKER_AMD64: docker.io/${{ github.repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-amd64
-            DOCKER_TAG: docker.io/${{ github.repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}
-            DOCKER_BRANCH: docker.io/${{ github.repository }}:${{ (startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-rc') && 'latest') || (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}
-            GHCR_ARM64: ghcr.io/${{ github.repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-arm64v8
-            GHCR_AMD64: ghcr.io/${{ github.repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-amd64
-            GHCR_TAG: ghcr.io/${{ github.repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}
-            GHCR_BRANCH: ghcr.io/${{ github.repository }}:${{ (startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-rc') && 'latest') || (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}
+            DOCKER_ARM64: docker.io/${{ needs.variables.outputs.github_repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-arm64v8
+            DOCKER_AMD64: docker.io/${{ needs.variables.outputs.github_repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-amd64
+            DOCKER_TAG: docker.io/${{ needs.variables.outputs.github_repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}
+            DOCKER_BRANCH: docker.io/${{ needs.variables.outputs.github_repository }}:${{ (startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-rc') && 'latest') || (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}
+            GHCR_ARM64: ghcr.io/${{ needs.variables.outputs.github_repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-arm64v8
+            GHCR_AMD64: ghcr.io/${{ needs.variables.outputs.github_repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-amd64
+            GHCR_TAG: ghcr.io/${{ needs.variables.outputs.github_repository }}:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}
+            GHCR_BRANCH: ghcr.io/${{ needs.variables.outputs.github_repository }}:${{ (startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-rc') && 'latest') || (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}
             GLCR_ARM64: registry.gitlab.com/conduwuit/conduwuit:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-arm64v8
             GLCR_AMD64: registry.gitlab.com/conduwuit/conduwuit:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}-amd64
             GLCR_TAG: registry.gitlab.com/conduwuit/conduwuit:${{ (github.head_ref != '' && format('merge-{0}-{1}', github.event.number, github.event.pull_request.user.login)) || github.ref_name }}-${{ github.sha }}
@@ -737,6 +754,12 @@ jobs:
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
             GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         steps:
+            - name: log variables
+              uses: actions/github-script@v7
+              id: var
+              with:
+                script: |
+                  console.log(`${{ toJson(needs) }}`)
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
               with:
@@ -771,95 +794,121 @@ jobs:
                   mv -v oci-image-aarch64-linux-musl-debug/*.tar.gz oci-image-arm64v8-debug.tar.gz
 
             - name: Load and push amd64 image
-              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker load -i oci-image-amd64.tar.gz
-                  docker tag $(docker images -q conduwuit:main) ${DOCKER_AMD64}
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${DOCKER_AMD64}
+                    docker push ${DOCKER_AMD64}
+                  fi
                   docker tag $(docker images -q conduwuit:main) ${GHCR_AMD64}
-                  docker tag $(docker images -q conduwuit:main) ${GLCR_AMD64}
-                  docker push ${DOCKER_AMD64}
                   docker push ${GHCR_AMD64}
-                  docker push ${GLCR_AMD64}
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GLCR_AMD64}
+                    docker push ${GLCR_AMD64}
+                  fi
 
             - name: Load and push arm64 image
-              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker load -i oci-image-arm64v8.tar.gz
-                  docker tag $(docker images -q conduwuit:main) ${DOCKER_ARM64}
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${DOCKER_ARM64}
+                    docker push ${DOCKER_ARM64}
+                  fi
                   docker tag $(docker images -q conduwuit:main) ${GHCR_ARM64}
-                  docker tag $(docker images -q conduwuit:main) ${GLCR_ARM64}
-                  docker push ${DOCKER_ARM64}
                   docker push ${GHCR_ARM64}
-                  docker push ${GLCR_ARM64}
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GLCR_ARM64}
+                    docker push ${GLCR_ARM64}
+                  fi
 
             - name: Load and push amd64 debug image
-              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker load -i oci-image-amd64-debug.tar.gz
-                  docker tag $(docker images -q conduwuit:main) ${DOCKER_AMD64}-debug
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${DOCKER_AMD64}-debug
+                    docker push ${DOCKER_AMD64}-debug
+                  fi
                   docker tag $(docker images -q conduwuit:main) ${GHCR_AMD64}-debug
-                  docker tag $(docker images -q conduwuit:main) ${GLCR_AMD64}-debug
-                  docker push ${DOCKER_AMD64}-debug
                   docker push ${GHCR_AMD64}-debug
-                  docker push ${GLCR_AMD64}-debug
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GLCR_AMD64}-debug
+                    docker push ${GLCR_AMD64}-debug
+                  fi
 
             - name: Load and push arm64 debug image
-              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
                   docker load -i oci-image-arm64v8-debug.tar.gz
-                  docker tag $(docker images -q conduwuit:main) ${DOCKER_ARM64}-debug
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${DOCKER_ARM64}-debug
+                    docker push ${DOCKER_ARM64}-debug
+                  fi
                   docker tag $(docker images -q conduwuit:main) ${GHCR_ARM64}-debug
-                  docker tag $(docker images -q conduwuit:main) ${GLCR_ARM64}-debug
-                  docker push ${DOCKER_ARM64}-debug
                   docker push ${GHCR_ARM64}-debug
-                  docker push ${GLCR_ARM64}-debug
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker tag $(docker images -q conduwuit:main) ${GLCR_ARM64}-debug
+                    docker push ${GLCR_ARM64}-debug
+                  fi
 
             - name: Create Docker combined manifests
               run: |
                   # Dockerhub Container Registry
-                  docker manifest create ${DOCKER_TAG} --amend ${DOCKER_ARM64} --amend ${DOCKER_AMD64}
-                  docker manifest create ${DOCKER_BRANCH} --amend ${DOCKER_ARM64} --amend ${DOCKER_AMD64}
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker manifest create ${DOCKER_TAG} --amend ${DOCKER_ARM64} --amend ${DOCKER_AMD64}
+                    docker manifest create ${DOCKER_BRANCH} --amend ${DOCKER_ARM64} --amend ${DOCKER_AMD64}
+                  fi
                   # GitHub Container Registry
                   docker manifest create ${GHCR_TAG} --amend ${GHCR_ARM64} --amend ${GHCR_AMD64}
                   docker manifest create ${GHCR_BRANCH} --amend ${GHCR_ARM64} --amend ${GHCR_AMD64}
                   # GitLab Container Registry
-                  docker manifest create ${GLCR_TAG} --amend ${GLCR_ARM64} --amend ${GLCR_AMD64}
-                  docker manifest create ${GLCR_BRANCH} --amend ${GLCR_ARM64} --amend ${GLCR_AMD64}
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker manifest create ${GLCR_TAG} --amend ${GLCR_ARM64} --amend ${GLCR_AMD64}
+                    docker manifest create ${GLCR_BRANCH} --amend ${GLCR_ARM64} --amend ${GLCR_AMD64}
+                  fi
 
             - name: Create Docker combined debug manifests
               run: |
                   # Dockerhub Container Registry
-                  docker manifest create ${DOCKER_TAG}-debug --amend ${DOCKER_ARM64}-debug --amend ${DOCKER_AMD64}-debug
-                  docker manifest create ${DOCKER_BRANCH}-debug --amend ${DOCKER_ARM64}-debug --amend ${DOCKER_AMD64}-debug
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker manifest create ${DOCKER_TAG}-debug --amend ${DOCKER_ARM64}-debug --amend ${DOCKER_AMD64}-debug
+                    docker manifest create ${DOCKER_BRANCH}-debug --amend ${DOCKER_ARM64}-debug --amend ${DOCKER_AMD64}-debug
+                  fi
                   # GitHub Container Registry
                   docker manifest create ${GHCR_TAG}-debug --amend ${GHCR_ARM64}-debug --amend ${GHCR_AMD64}-debug
                   docker manifest create ${GHCR_BRANCH}-debug --amend ${GHCR_ARM64}-debug --amend ${GHCR_AMD64}-debug
                   # GitLab Container Registry
-                  docker manifest create ${GLCR_TAG}-debug --amend ${GLCR_ARM64}-debug --amend ${GLCR_AMD64}-debug
-                  docker manifest create ${GLCR_BRANCH}-debug --amend ${GLCR_ARM64}-debug --amend ${GLCR_AMD64}-debug
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker manifest create ${GLCR_TAG}-debug --amend ${GLCR_ARM64}-debug --amend ${GLCR_AMD64}-debug
+                    docker manifest create ${GLCR_BRANCH}-debug --amend ${GLCR_ARM64}-debug --amend ${GLCR_AMD64}-debug
+                  fi
 
             - name: Push manifests to Docker registries
-              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
-                  docker manifest push ${DOCKER_TAG}
-                  docker manifest push ${DOCKER_BRANCH}
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    docker manifest push ${DOCKER_TAG}
+                    docker manifest push ${DOCKER_BRANCH}
+                    docker manifest push ${DOCKER_TAG}-debug
+                    docker manifest push ${DOCKER_BRANCH}-debug
+                  fi
                   docker manifest push ${GHCR_TAG}
                   docker manifest push ${GHCR_BRANCH}
-                  docker manifest push ${GLCR_TAG}
-                  docker manifest push ${GLCR_BRANCH}
-                  docker manifest push ${DOCKER_TAG}-debug
-                  docker manifest push ${DOCKER_BRANCH}-debug
                   docker manifest push ${GHCR_TAG}-debug
                   docker manifest push ${GHCR_BRANCH}-debug
-                  docker manifest push ${GLCR_TAG}-debug
-                  docker manifest push ${GLCR_BRANCH}-debug
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    docker manifest push ${GLCR_TAG}
+                    docker manifest push ${GLCR_BRANCH}
+                    docker manifest push ${GLCR_TAG}-debug
+                    docker manifest push ${GLCR_BRANCH}-debug
+                  fi
 
             - name: Add Image Links to Job Summary
-              if: ${{ (vars.DOCKER_USERNAME != '') && (env.DOCKERHUB_TOKEN != '') }}
               run: |
-                  echo "- \`docker pull ${DOCKER_TAG}\`" >> $GITHUB_STEP_SUMMARY
+                  if [ ! -z $DOCKERHUB_TOKEN ]; then
+                    echo "- \`docker pull ${DOCKER_TAG}\`" >> $GITHUB_STEP_SUMMARY
+                    echo "- \`docker pull ${DOCKER_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
+                  fi
                   echo "- \`docker pull ${GHCR_TAG}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- \`docker pull ${GLCR_TAG}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- \`docker pull ${DOCKER_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
                   echo "- \`docker pull ${GHCR_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- \`docker pull ${GLCR_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
+                  if [ ! -z $GITLAB_TOKEN ]; then
+                    echo "- \`docker pull ${GLCR_TAG}\`" >> $GITHUB_STEP_SUMMARY
+                    echo "- \`docker pull ${GLCR_TAG}-debug\`" >> $GITHUB_STEP_SUMMARY
+                  fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,7 +727,6 @@ jobs:
           id: var
           with:
             script: |
-              console.log('${{ github.repository }}'.toLowerCase())
               core.setOutput('github_repository', '${{ github.repository }}'.toLowerCase())
     docker:
         name: Docker publish
@@ -754,12 +753,6 @@ jobs:
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
             GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         steps:
-            - name: log variables
-              uses: actions/github-script@v7
-              id: var
-              with:
-                script: |
-                  console.log(`${{ toJson(needs) }}`)
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
               with:


### PR DESCRIPTION
This commit contains two separate fixes:

1) use lowercased github username/repository for the docker repository name. 
This is because image registries only accept lowercase in image repository names, but github stores the repository and username in a case-sensitive manner. This broke image uploads for me, as my username has uppercase chars.

2) change run conditions for some steps.
It will no longer attempt to set up SSH web publishing if the SSH private key is not set.
It will also run the image registry upload steps if registry usernames are missing, instead skipping individual uploads where the token for that registry is missing.

Finally, it simplifies the sccache run conditions to use the `SCCACHE_GHA_ENABLED` env variable, rather than duplicating that logic.