### PR TITLE
Publish README to docker hub

### DIFF
--- a/.github/workflows/docker-hub-description.yml
+++ b/.github/workflows/docker-hub-description.yml
@@ -1,0 +1,36 @@
+name: Update Docker Hub Description
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - .github/workflows/docker-hub-description.yml
+
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Setting variables
+      uses: actions/github-script@v7
+      id: var
+      with:
+        script: |
+          const githubRepo = '${{ github.repository }}'.toLowerCase()
+          const repoId = githubRepo.split('/')[1]
+          
+          core.setOutput('github_repository', githubRepo)
+          const dockerRepo = '${{ vars.DOCKER_USERNAME }}'.toLowerCase() + '/' + repoId
+          core.setOutput('docker_repo', dockerRepo)
+    - name: Docker Hub Description
+      uses: peter-evans/dockerhub-description@v4
+      with:
+        username: ${{ vars.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: ${{ steps.var.outputs.docker_repo }}
+        short-description: ${{ github.event.repository.description }}
+        enable-url-completion: true


### PR DESCRIPTION
Adds a github action to push the README to docker.io automatically.
Only runs on the main branch, when the README or workflow change. 
