### PR TITLE
Implement `/login/get_token`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,6 @@ dependencies = [
  "http-body-util",
  "hyper",
  "ipaddress",
- "jsonwebtoken",
  "log",
  "rand",
  "reqwest",
@@ -831,7 +830,6 @@ dependencies = [
  "image",
  "ipaddress",
  "itertools 0.13.0",
- "jsonwebtoken",
  "log",
  "loole",
  "lru-cache",
@@ -2113,19 +2111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "ring",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,6 @@ features = ["parse"]
 [workspace.dependencies.sanitize-filename]
 version = "0.6.0"
 
-[workspace.dependencies.jsonwebtoken]
-version = "9.3.0"
-default-features = false
-
 [workspace.dependencies.base64]
 version = "0.22.1"
 default-features = false

--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -645,6 +645,22 @@
 #
 #openid_token_ttl = 3600
 
+# Allow an existing session to mint a login token for another client.
+# This requires interactive authentication, but has security ramifications
+# as a malicious client could use the mechanism to spawn more than one
+# session.
+# Enabled by default.
+#
+#login_via_existing_session = true
+
+# Login token expiration/TTL in milliseconds.
+#
+# These are short-lived tokens for the m.login.token endpoint.
+# This is used to allow existing sessions to create new sessions.
+# see login_via_existing_session.
+#
+#login_token_ttl = 120000
+
 # Static TURN username to provide the client if not using a shared secret
 # ("turn_secret"), It is recommended to use a shared secret over static
 # credentials.

--- a/conduwuit-example.toml
+++ b/conduwuit-example.toml
@@ -563,10 +563,6 @@
 #
 #proxy = "none"
 
-# This item is undocumented. Please contribute documentation for it.
-#
-#jwt_secret =
-
 # Servers listed here will be used to gather public keys of other servers
 # (notary trusted key servers).
 #

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -50,7 +50,6 @@ http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 ipaddress.workspace = true
-jsonwebtoken.workspace = true
 log.workspace = true
 rand.workspace = true
 reqwest.workspace = true

--- a/src/api/client/capabilities.rs
+++ b/src/api/client/capabilities.rs
@@ -32,8 +32,9 @@ pub(crate) async fn get_capabilities_route(
 	// we do not implement 3PID stuff
 	capabilities.thirdparty_id_changes = ThirdPartyIdChangesCapability { enabled: false };
 
-	// we dont support generating tokens yet
-	capabilities.get_login_token = GetLoginTokenCapability { enabled: false };
+	capabilities.get_login_token = GetLoginTokenCapability {
+		enabled: services.server.config.login_via_existing_session,
+	};
 
 	// MSC4133 capability
 	capabilities

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -34,6 +34,7 @@ pub fn build(router: Router<State>, server: &Server) -> Router<State> {
 		.ruma_route(&client::register_route)
 		.ruma_route(&client::get_login_types_route)
 		.ruma_route(&client::login_route)
+		.ruma_route(&client::login_token_route)
 		.ruma_route(&client::whoami_route)
 		.ruma_route(&client::logout_route)
 		.ruma_route(&client::logout_all_route)

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -767,6 +767,24 @@ pub struct Config {
 	#[serde(default = "default_openid_token_ttl")]
 	pub openid_token_ttl: u64,
 
+	/// Allow an existing session to mint a login token for another client.
+	/// This requires interactive authentication, but has security ramifications
+	/// as a malicious client could use the mechanism to spawn more than one
+	/// session.
+	/// Enabled by default.
+	#[serde(default = "true_fn")]
+	pub login_via_existing_session: bool,
+
+	/// Login token expiration/TTL in milliseconds.
+	///
+	/// These are short-lived tokens for the m.login.token endpoint.
+	/// This is used to allow existing sessions to create new sessions.
+	/// see login_via_existing_session.
+	///
+	/// default: 120000
+	#[serde(default = "default_login_token_ttl")]
+	pub login_token_ttl: u64,
+
 	/// Static TURN username to provide the client if not using a shared secret
 	/// ("turn_secret"), It is recommended to use a shared secret over static
 	/// credentials.
@@ -2372,6 +2390,8 @@ pub fn default_log_span_events() -> String { "none".into() }
 fn default_notification_push_path() -> String { "/_matrix/push/v1/notify".to_owned() }
 
 fn default_openid_token_ttl() -> u64 { 60 * 60 }
+
+fn default_login_token_ttl() -> u64 { 2 * 60 * 1000 }
 
 fn default_turn_ttl() -> u64 { 60 * 60 * 24 }
 

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -671,8 +671,6 @@ pub struct Config {
 	#[serde(default)]
 	pub proxy: ProxyConfig,
 
-	pub jwt_secret: Option<String>,
-
 	/// Servers listed here will be used to gather public keys of other servers
 	/// (notary trusted key servers).
 	///
@@ -2005,10 +2003,6 @@ impl fmt::Display for Config {
 			"Lockdown public room directory (only allow admins to publish)",
 			&self.lockdown_public_room_directory.to_string(),
 		);
-		line("JWT secret", match self.jwt_secret {
-			| Some(_) => "set",
-			| None => "not set",
-		});
 		line(
 			"Trusted key servers",
 			&self

--- a/src/database/maps.rs
+++ b/src/database/maps.rs
@@ -366,6 +366,10 @@ pub(super) static MAPS: &[Descriptor] = &[
 		..descriptor::RANDOM_SMALL
 	},
 	Descriptor {
+		name: "logintoken_expiresatuserid",
+		..descriptor::RANDOM_SMALL
+	},
+	Descriptor {
 		name: "userroomid_highlightcount",
 		..descriptor::RANDOM
 	},

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -61,7 +61,6 @@ image.workspace = true
 image.optional = true
 ipaddress.workspace = true
 itertools.workspace = true
-jsonwebtoken.workspace = true
 log.workspace = true
 loole.workspace = true
 lru-cache.workspace = true

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -18,7 +18,6 @@ pub struct Service {
 	pub db: Data,
 
 	pub config: Config,
-	jwt_decoding_key: Option<jsonwebtoken::DecodingKey>,
 	pub bad_event_ratelimiter: Arc<RwLock<HashMap<OwnedEventId, RateLimitState>>>,
 	pub server_user: OwnedUserId,
 	pub admin_alias: OwnedRoomAliasId,
@@ -32,11 +31,6 @@ impl crate::Service for Service {
 	fn build(args: crate::Args<'_>) -> Result<Arc<Self>> {
 		let db = Data::new(&args);
 		let config = &args.server.config;
-
-		let jwt_decoding_key = config
-			.jwt_secret
-			.as_ref()
-			.map(|secret| jsonwebtoken::DecodingKey::from_secret(secret.as_bytes()));
 
 		let turn_secret =
 			config
@@ -66,7 +60,6 @@ impl crate::Service for Service {
 		let mut s = Self {
 			db,
 			config: config.clone(),
-			jwt_decoding_key,
 			bad_event_ratelimiter: Arc::new(RwLock::new(HashMap::new())),
 			admin_alias: OwnedRoomAliasId::try_from(format!("#admins:{}", &config.server_name))
 				.expect("#admins:server_name is valid alias name"),
@@ -157,10 +150,6 @@ impl Service {
 	pub fn allow_check_for_updates(&self) -> bool { self.config.allow_check_for_updates }
 
 	pub fn trusted_servers(&self) -> &[OwnedServerName] { &self.config.trusted_servers }
-
-	pub fn jwt_decoding_key(&self) -> Option<&jsonwebtoken::DecodingKey> {
-		self.jwt_decoding_key.as_ref()
-	}
 
 	pub fn turn_password(&self) -> &String { &self.config.turn_password }
 


### PR DESCRIPTION
This is a component of QR login without OIDC. (the other one being the insecure rendezvous endpoint for encryption, also used for OIDC QR login)

It allows existing sessions to generate short-lived tokens which can be used to login a new session. Tokens are automatically deleted on use.
I've added two new config options, one allowing disabling the generation and usage of the tokens and the other setting the length the tokens are valid for (by default two minutes). For some reason, the example config isn't regenerating, though.

Calling the `/login/get_token` endpoint requires UIA. I've not been able to work out how to reject UIA sessions that have been used before (a security feature required by the spec). This might require storing additional state in the database.


I've also removed the undocumented `jwt_secret` option and related code - it seems this was a part of a SSO implementation. https://github.com/girlbossceo/conduwuit/commit/d49911c5e01ca1e1a6d14533bcf6ae47a146fe49

