### PR TITLE
Federation allow list

### DIFF
--- a/src/api/client/directory.rs
+++ b/src/api/client/directory.rs
@@ -45,6 +45,7 @@ pub(crate) async fn get_public_rooms_filtered_route(
 			.config
 			.forbidden_remote_room_directory_server_names
 			.contains(server)
+			|| services.moderation.is_remote_server_forbidden(server)
 		{
 			return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 		}
@@ -87,6 +88,7 @@ pub(crate) async fn get_public_rooms_route(
 			.config
 			.forbidden_remote_room_directory_server_names
 			.contains(server)
+			|| services.moderation.is_remote_server_forbidden(server)
 		{
 			return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 		}

--- a/src/api/client/membership.rs
+++ b/src/api/client/membership.rs
@@ -71,10 +71,8 @@ async fn banned_room_check(
 	if let Some(room_id) = room_id {
 		if services.rooms.metadata.is_banned(room_id).await
 			|| services
-				.globals
-				.config
-				.forbidden_remote_server_names
-				.contains(&room_id.server_name().unwrap().to_owned())
+				.moderation
+				.is_remote_server_forbidden(room_id.server_name().unwrap())
 		{
 			warn!(
 				"User {user_id} who is not an admin attempted to send an invite for or \
@@ -112,10 +110,8 @@ async fn banned_room_check(
 		}
 	} else if let Some(server_name) = server_name {
 		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server_name.to_owned())
+			.moderation
+			.is_remote_server_forbidden(server_name)
 		{
 			warn!(
 				"User {user_id} who is not an admin tried joining a room which has the server \

--- a/src/api/client/membership.rs
+++ b/src/api/client/membership.rs
@@ -109,10 +109,7 @@ async fn banned_room_check(
 			return Err!(Request(Forbidden("This room is banned on this homeserver.")));
 		}
 	} else if let Some(server_name) = server_name {
-		if services
-			.moderation
-			.is_remote_server_forbidden(server_name)
-		{
+		if services.moderation.is_remote_server_forbidden(server_name) {
 			warn!(
 				"User {user_id} who is not an admin tried joining a room which has the server \
 				 name {server_name} that is globally forbidden. Rejecting.",

--- a/src/api/client/message.rs
+++ b/src/api/client/message.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use axum::extract::State;
 use conduwuit::{
-	at, is_equal_to,
+	at,
 	utils::{
 		result::{FlatOk, LogErr},
 		stream::{BroadbandExt, TryIgnore, WidebandExt},
@@ -236,11 +236,8 @@ pub(crate) async fn ignored_filter(
 	if IGNORED_MESSAGE_TYPES.binary_search(&pdu.kind).is_ok()
 		&& (services.users.user_is_ignored(&pdu.sender, user_id).await
 			|| services
-				.server
-				.config
-				.forbidden_remote_server_names
-				.iter()
-				.any(is_equal_to!(pdu.sender().server_name())))
+				.moderation
+				.is_remote_server_forbidden(pdu.sender().server_name()))
 	{
 		return None;
 	}

--- a/src/api/router/auth.rs
+++ b/src/api/router/auth.rs
@@ -317,12 +317,7 @@ fn auth_server_checks(services: &Services, x_matrix: &XMatrix) -> Result<()> {
 	}
 
 	let origin = &x_matrix.origin;
-	if services
-		.server
-		.config
-		.forbidden_remote_server_names
-		.contains(origin)
-	{
+	if services.moderation.is_remote_server_forbidden(origin) {
 		return Err!(Request(Forbidden(debug_warn!(
 			"Federation requests from {origin} denied."
 		))));

--- a/src/api/server/invite.rs
+++ b/src/api/server/invite.rs
@@ -37,20 +37,16 @@ pub(crate) async fn create_invite_route(
 
 	if let Some(server) = body.room_id.server_name() {
 		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server.to_owned())
+			.moderation
+			.is_remote_server_forbidden(server)
 		{
 			return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 		}
 	}
 
 	if services
-		.globals
-		.config
-		.forbidden_remote_server_names
-		.contains(body.origin())
+		.moderation
+		.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Received federated/remote invite from banned server {} for room ID {}. Rejecting.",

--- a/src/api/server/invite.rs
+++ b/src/api/server/invite.rs
@@ -36,10 +36,7 @@ pub(crate) async fn create_invite_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services
-			.moderation
-			.is_remote_server_forbidden(server)
-		{
+		if services.moderation.is_remote_server_forbidden(server) {
 			return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 		}
 	}

--- a/src/api/server/make_join.rs
+++ b/src/api/server/make_join.rs
@@ -56,10 +56,7 @@ pub(crate) async fn create_join_event_template_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services
-			.moderation
-			.is_remote_server_forbidden(server)
-		{
+		if services.moderation.is_remote_server_forbidden(server) {
 			return Err!(Request(Forbidden(warn!(
 				"Room ID server name {server} is banned on this homeserver."
 			))));

--- a/src/api/server/make_join.rs
+++ b/src/api/server/make_join.rs
@@ -42,10 +42,8 @@ pub(crate) async fn create_join_event_template_route(
 		.await?;
 
 	if services
-		.globals
-		.config
-		.forbidden_remote_server_names
-		.contains(body.origin())
+		.moderation
+		.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Server {} for remote user {} tried joining room ID {} which has a server name that \
@@ -59,10 +57,8 @@ pub(crate) async fn create_join_event_template_route(
 
 	if let Some(server) = body.room_id.server_name() {
 		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server.to_owned())
+			.moderation
+			.is_remote_server_forbidden(server)
 		{
 			return Err!(Request(Forbidden(warn!(
 				"Room ID server name {server} is banned on this homeserver."

--- a/src/api/server/make_knock.rs
+++ b/src/api/server/make_knock.rs
@@ -33,7 +33,9 @@ pub(crate) async fn create_knock_event_template_route(
 		.acl_check(body.origin(), &body.room_id)
 		.await?;
 
-	if services.moderation.is_remote_server_forbidden(body.origin())
+	if services
+		.moderation
+		.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Server {} for remote user {} tried knocking room ID {} which has a server name \
@@ -46,7 +48,9 @@ pub(crate) async fn create_knock_event_template_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services.moderation.is_remote_server_forbidden(&server.to_owned())
+		if services
+			.moderation
+			.is_remote_server_forbidden(&server.to_owned())
 		{
 			return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 		}

--- a/src/api/server/make_knock.rs
+++ b/src/api/server/make_knock.rs
@@ -33,11 +33,7 @@ pub(crate) async fn create_knock_event_template_route(
 		.acl_check(body.origin(), &body.room_id)
 		.await?;
 
-	if services
-		.globals
-		.config
-		.forbidden_remote_server_names
-		.contains(body.origin())
+	if services.moderation.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Server {} for remote user {} tried knocking room ID {} which has a server name \
@@ -50,11 +46,7 @@ pub(crate) async fn create_knock_event_template_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server.to_owned())
+		if services.moderation.is_remote_server_forbidden(&server.to_owned())
 		{
 			return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 		}

--- a/src/api/server/send_join.rs
+++ b/src/api/server/send_join.rs
@@ -268,10 +268,8 @@ pub(crate) async fn create_join_event_v1_route(
 	body: Ruma<create_join_event::v1::Request>,
 ) -> Result<create_join_event::v1::Response> {
 	if services
-		.globals
-		.config
-		.forbidden_remote_server_names
-		.contains(body.origin())
+		.moderation
+		.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Server {} tried joining room ID {} through us who has a server name that is \
@@ -284,10 +282,8 @@ pub(crate) async fn create_join_event_v1_route(
 
 	if let Some(server) = body.room_id.server_name() {
 		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server.to_owned())
+			.moderation
+			.is_remote_server_forbidden(server)
 		{
 			warn!(
 				"Server {} tried joining room ID {} through us which has a server name that is \
@@ -316,20 +312,16 @@ pub(crate) async fn create_join_event_v2_route(
 	body: Ruma<create_join_event::v2::Request>,
 ) -> Result<create_join_event::v2::Response> {
 	if services
-		.globals
-		.config
-		.forbidden_remote_server_names
-		.contains(body.origin())
+		.moderation
+		.is_remote_server_forbidden(body.origin())
 	{
 		return Err!(Request(Forbidden("Server is banned on this homeserver.")));
 	}
 
 	if let Some(server) = body.room_id.server_name() {
 		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server.to_owned())
+			.moderation
+			.is_remote_server_forbidden(server)
 		{
 			warn!(
 				"Server {} tried joining room ID {} through us which has a server name that is \

--- a/src/api/server/send_join.rs
+++ b/src/api/server/send_join.rs
@@ -281,10 +281,7 @@ pub(crate) async fn create_join_event_v1_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services
-			.moderation
-			.is_remote_server_forbidden(server)
-		{
+		if services.moderation.is_remote_server_forbidden(server) {
 			warn!(
 				"Server {} tried joining room ID {} through us which has a server name that is \
 				 globally forbidden. Rejecting.",
@@ -319,10 +316,7 @@ pub(crate) async fn create_join_event_v2_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services
-			.moderation
-			.is_remote_server_forbidden(server)
-		{
+		if services.moderation.is_remote_server_forbidden(server) {
 			warn!(
 				"Server {} tried joining room ID {} through us which has a server name that is \
 				 globally forbidden. Rejecting.",

--- a/src/api/server/send_knock.rs
+++ b/src/api/server/send_knock.rs
@@ -21,7 +21,9 @@ pub(crate) async fn create_knock_event_v1_route(
 	State(services): State<crate::State>,
 	body: Ruma<send_knock::v1::Request>,
 ) -> Result<send_knock::v1::Response> {
-	if services.moderation.is_remote_server_forbidden(body.origin())
+	if services
+		.moderation
+		.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Server {} tried knocking room ID {} who has a server name that is globally \
@@ -33,7 +35,9 @@ pub(crate) async fn create_knock_event_v1_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services.moderation.is_remote_server_forbidden(&server.to_owned())
+		if services
+			.moderation
+			.is_remote_server_forbidden(&server.to_owned())
 		{
 			warn!(
 				"Server {} tried knocking room ID {} which has a server name that is globally \

--- a/src/api/server/send_knock.rs
+++ b/src/api/server/send_knock.rs
@@ -21,11 +21,7 @@ pub(crate) async fn create_knock_event_v1_route(
 	State(services): State<crate::State>,
 	body: Ruma<send_knock::v1::Request>,
 ) -> Result<send_knock::v1::Response> {
-	if services
-		.globals
-		.config
-		.forbidden_remote_server_names
-		.contains(body.origin())
+	if services.moderation.is_remote_server_forbidden(body.origin())
 	{
 		warn!(
 			"Server {} tried knocking room ID {} who has a server name that is globally \
@@ -37,11 +33,7 @@ pub(crate) async fn create_knock_event_v1_route(
 	}
 
 	if let Some(server) = body.room_id.server_name() {
-		if services
-			.globals
-			.config
-			.forbidden_remote_server_names
-			.contains(&server.to_owned())
+		if services.moderation.is_remote_server_forbidden(&server.to_owned())
 		{
 			warn!(
 				"Server {} tried knocking room ID {} which has a server name that is globally \

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1282,6 +1282,8 @@ pub struct Config {
 	/// Vector list of servers that conduwuit will refuse to download remote
 	/// media from.
 	///
+	/// This is in addition to `forbidden_remote_server_names`.
+	///
 	/// default: []
 	#[serde(default)]
 	pub prevent_media_downloads_from: HashSet<OwnedServerName>,
@@ -1312,6 +1314,8 @@ pub struct Config {
 	/// List of forbidden server names that we will block all outgoing federated
 	/// room directory requests for. Useful for preventing our users from
 	/// wandering into bad servers or spaces.
+	///
+	/// This is in addition to `forbidden_remote_server_names`.
 	///
 	/// default: []
 	#[serde(default = "HashSet::new")]

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1293,11 +1293,21 @@ pub struct Config {
 	/// sender user's server name, inbound federation X-Matrix origin, and
 	/// outbound federation handler.
 	///
+	/// Additionally, it will hide messages from these servers for all users
+	/// on this server.
+	///
 	/// Basically "global" ACLs.
 	///
 	/// default: []
 	#[serde(default)]
 	pub forbidden_remote_server_names: HashSet<OwnedServerName>,
+
+	/// The inverse of `forbidden_remote_server_names`. By default, allows all
+	/// servers. `forbidden_remote_server_names` takes precidence.
+	///
+	/// default: []
+	#[serde(default)]
+	pub allowed_remote_server_names: HashSet<OwnedServerName>,
 
 	/// List of forbidden server names that we will block all outgoing federated
 	/// room directory requests for. Useful for preventing our users from
@@ -2117,6 +2127,13 @@ impl fmt::Display for Config {
 		line("Forbidden Remote Server Names (\"Global\" ACLs)", {
 			let mut lst = Vec::with_capacity(self.forbidden_remote_server_names.len());
 			for domain in &self.forbidden_remote_server_names {
+				lst.push(domain.host());
+			}
+			&lst.join(", ")
+		});
+		line("Allowed Remote Server Names", {
+			let mut lst = Vec::with_capacity(self.allowed_remote_server_names.len());
+			for domain in &self.allowed_remote_server_names {
 				lst.push(domain.host());
 			}
 			&lst.join(", ")

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1818,7 +1818,7 @@ impl Config {
 		let mut addrs = Vec::with_capacity(
 			self.get_bind_hosts()
 				.len()
-				.saturating_add(self.get_bind_ports().len()),
+				.saturating_mul(self.get_bind_ports().len()),
 		);
 		for host in &self.get_bind_hosts() {
 			for port in &self.get_bind_ports() {

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -22,7 +22,7 @@ use tokio::{
 
 use self::data::{Data, Metadata};
 pub use self::thumbnail::Dim;
-use crate::{client, globals, sending, Dep};
+use crate::{client, globals, moderation, sending, Dep};
 
 #[derive(Debug)]
 pub struct FileMeta {
@@ -42,6 +42,7 @@ struct Services {
 	client: Dep<client::Service>,
 	globals: Dep<globals::Service>,
 	sending: Dep<sending::Service>,
+	moderation: Dep<moderation::Service>,
 }
 
 /// generated MXC ID (`media-id`) length
@@ -64,6 +65,7 @@ impl crate::Service for Service {
 				client: args.depend::<client::Service>("client"),
 				globals: args.depend::<globals::Service>("globals"),
 				sending: args.depend::<sending::Service>("sending"),
+				moderation: args.depend::<moderation::Service>("moderation"),
 			},
 		}))
 	}

--- a/src/service/media/remote.rs
+++ b/src/service/media/remote.rs
@@ -427,6 +427,10 @@ fn check_fetch_authorized(&self, mxc: &Mxc<'_>) -> Result<()> {
 		.config
 		.prevent_media_downloads_from
 		.contains(mxc.server_name)
+		|| self
+			.services
+			.moderation
+			.is_remote_server_forbidden(mxc.server_name)
 	{
 		// we'll lie to the client and say the blocked server's media was not found and
 		// log. the client has no way of telling anyways so this is a security bonus.

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -13,6 +13,7 @@ pub mod emergency;
 pub mod globals;
 pub mod key_backups;
 pub mod media;
+pub mod moderation;
 pub mod presence;
 pub mod pusher;
 pub mod resolver;

--- a/src/service/moderation/mod.rs
+++ b/src/service/moderation/mod.rs
@@ -27,7 +27,7 @@ impl crate::Service for Service {
 
 #[implement(Service)]
 pub fn is_remote_server_forbidden(&self, server_name: &ServerName) -> bool {
-	// Forbidden if NOT (allowed is empty OR allowed contains server)
+	// Forbidden if NOT (allowed is empty OR allowed contains server OR is self)
 	// OR forbidden contains server
 	!(self
 		.services
@@ -40,7 +40,8 @@ pub fn is_remote_server_forbidden(&self, server_name: &ServerName) -> bool {
 			.globals
 			.config
 			.allowed_remote_server_names
-			.contains(server_name))
+			.contains(server_name)
+		|| server_name == self.services.globals.server_name())
 		|| self
 			.services
 			.globals

--- a/src/service/moderation/mod.rs
+++ b/src/service/moderation/mod.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use conduwuit::{implement, Result};
+use ruma::ServerName;
+
+use crate::{globals, Dep};
+
+pub struct Service {
+	services: Services,
+}
+
+struct Services {
+	globals: Dep<globals::Service>,
+}
+
+impl crate::Service for Service {
+	fn build(args: crate::Args<'_>) -> Result<Arc<Self>> {
+		Ok(Arc::new(Self {
+			services: Services {
+				globals: args.depend::<globals::Service>("globals"),
+			},
+		}))
+	}
+
+	fn name(&self) -> &str { crate::service::make_name(std::module_path!()) }
+}
+
+#[implement(Service)]
+pub fn is_remote_server_forbidden(&self, server_name: &ServerName) -> bool {
+	// Forbidden if NOT (allowed is empty OR allowed contains server)
+	// OR forbidden contains server
+	!(self
+		.services
+		.globals
+		.config
+		.allowed_remote_server_names
+		.is_empty()
+		|| self
+			.services
+			.globals
+			.config
+			.allowed_remote_server_names
+			.contains(server_name))
+		|| self
+			.services
+			.globals
+			.config
+			.forbidden_remote_server_names
+			.contains(server_name)
+}

--- a/src/service/sending/mod.rs
+++ b/src/service/sending/mod.rs
@@ -30,7 +30,8 @@ pub use self::{
 	sender::{EDU_LIMIT, PDU_LIMIT},
 };
 use crate::{
-	account_data, client, globals, presence, pusher, resolver, rooms, rooms::timeline::RawPduId,
+	account_data, client, globals, moderation, presence, pusher, resolver,
+	rooms::{self, timeline::RawPduId},
 	server_keys, users, Dep,
 };
 
@@ -56,6 +57,7 @@ struct Services {
 	appservice: Dep<crate::appservice::Service>,
 	pusher: Dep<pusher::Service>,
 	server_keys: Dep<server_keys::Service>,
+	moderation: Dep<moderation::Service>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -95,6 +97,7 @@ impl crate::Service for Service {
 				appservice: args.depend::<crate::appservice::Service>("appservice"),
 				pusher: args.depend::<pusher::Service>("pusher"),
 				server_keys: args.depend::<server_keys::Service>("server_keys"),
+				moderation: args.depend::<moderation::Service>("moderation"),
 			},
 			channels: (0..num_senders).map(|_| loole::unbounded()).collect(),
 		}))

--- a/src/service/sending/send.rs
+++ b/src/service/sending/send.rs
@@ -41,12 +41,7 @@ impl super::Service {
 			return Err!(Config("allow_federation", "Federation is disabled."));
 		}
 
-		if self
-			.server
-			.config
-			.forbidden_remote_server_names
-			.contains(dest)
-		{
+		if self.services.moderation.is_remote_server_forbidden(dest) {
 			return Err!(Request(Forbidden(debug_warn!(
 				"Federation with {dest} is not allowed."
 			))));

--- a/src/service/services.rs
+++ b/src/service/services.rs
@@ -12,8 +12,8 @@ use tokio::sync::Mutex;
 use crate::{
 	account_data, admin, appservice, client, emergency, globals, key_backups,
 	manager::Manager,
-	media, presence, pusher, resolver, rooms, sending, server_keys, service,
-	service::{Args, Map, Service},
+	media, moderation, presence, pusher, resolver, rooms, sending, server_keys,
+	service::{self, Args, Map, Service},
 	sync, transaction_ids, uiaa, updates, users,
 };
 
@@ -30,6 +30,7 @@ pub struct Services {
 	pub pusher: Arc<pusher::Service>,
 	pub resolver: Arc<resolver::Service>,
 	pub rooms: rooms::Service,
+	pub moderation: Arc<moderation::Service>,
 	pub sending: Arc<sending::Service>,
 	pub server_keys: Arc<server_keys::Service>,
 	pub sync: Arc<sync::Service>,
@@ -95,6 +96,7 @@ impl Services {
 				typing: build!(rooms::typing::Service),
 				user: build!(rooms::user::Service),
 			},
+			moderation: build!(moderation::Service),
 			sending: build!(sending::Service),
 			server_keys: build!(server_keys::Service),
 			sync: build!(sync::Service),


### PR DESCRIPTION
This adds an `allowed_remote_server_names`. When empty, all remote servers are allowed. When set, servers not in the list are treated the same as `forbidden_remote_server_names`.

This additionally makes these options apply to remote media fetching and remote room directory fetching.

Not sure if ignoring messages from servers not in the allow-list is the best behaviour - it may result in some unexpected behaviour in cases like #672, where users are in a room with a non-allowed user via an allowed user. Perhaps this should be a separate option?

Unfortunately, the example config won't regenerate for me. 
Waiting on CI to build to give this a final test. 


A useful enhancement for this and related options may be glob matching, or reading from a policy room. Out of scope for this, though.