### PR TITLE
Fix in caddyfile guide

### DIFF
--- a/docs/deploying/generic.md
+++ b/docs/deploying/generic.md
@@ -216,7 +216,7 @@ your server name).
 ```caddyfile
 your.server.name, your.server.name:8448 {
     # TCP reverse_proxy
-    127.0.0.1:6167
+    reverse_proxy 127.0.0.1:6167
     # UNIX socket
     #reverse_proxy unix//run/conduwuit/conduwuit.sock
 }


### PR DESCRIPTION
If the reverse_proxy directive is omitted before 127.0.0.1:6167 in your Caddyfile, enabling the service with systemctl enable will result in an error.