### PR TITLE
 Fix off-by-one error in room hierarchy endpoint (take 2)

### DIFF
--- a/src/api/client/space.rs
+++ b/src/api/client/space.rs
@@ -159,7 +159,7 @@ where
 					break;
 				}
 
-				if parents.len() >= max_depth {
+				if parents.len() > max_depth {
 					continue;
 				}
 

--- a/tests/test_results/complement/test_results.jsonl
+++ b/tests/test_results/complement/test_results.jsonl
@@ -73,7 +73,7 @@
 {"Action":"pass","Test":"TestChangePasswordPushers/Pushers_created_with_a_different_access_token_are_deleted_on_password_change"}
 {"Action":"pass","Test":"TestChangePasswordPushers/Pushers_created_with_the_same_access_token_are_not_deleted_on_password_change"}
 {"Action":"fail","Test":"TestClientSpacesSummary"}
-{"Action":"fail","Test":"TestClientSpacesSummary/max_depth"}
+{"Action":"pass","Test":"TestClientSpacesSummary/max_depth"}
 {"Action":"fail","Test":"TestClientSpacesSummary/pagination"}
 {"Action":"fail","Test":"TestClientSpacesSummary/query_whole_graph"}
 {"Action":"fail","Test":"TestClientSpacesSummary/redact_link"}


### PR DESCRIPTION
This PR fixes requests to `/_matrix/client/v1/rooms/<id>/hierarchy?max_depth=1` only returning the space with the provided ID, excluding its children and causing Element and Cinny to claim the space is empty.