### PR TITLE
config: rocksdb_compaction help was inverted :-)

### DIFF
--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1133,8 +1133,8 @@ pub struct Config {
 	#[serde(default = "true_fn")]
 	pub rocksdb_compaction_ioprio_idle: bool,
 
-	/// Disables RocksDB compaction. You should never ever have to set this
-	/// option to true. If you for some reason find yourself needing to use this
+	/// Enables RocksDB compaction. You should never ever have to set this
+	/// option to false. If you for some reason find yourself needing to use this
 	/// option as part of troubleshooting or a bug, please reach out to us in
 	/// the conduwuit Matrix room with information and details.
 	///


### PR DESCRIPTION
You seem to have replaced `disable_rocksdb_compaction` with `rocksdb_compaction`, since the help is blackmailing me never ever ever to set it to `true`, except **true is the default**.

I have tried to make it say what you possibly meant.